### PR TITLE
Clean up 'Game' enum.

### DIFF
--- a/common.py
+++ b/common.py
@@ -64,16 +64,16 @@ class Games(Enum):
 
     def __new__(cls, value, pretty_name, min_players):
         """This odd constructor lets us keep Foo.value as an integer, but also
-	   add some extra properties to each option."""
+           add some extra properties to each option."""
         obj = object.__new__(cls)
         obj._value_ = value
         obj.pretty_name = pretty_name
-	obj.minimum_players = min_players
+        obj.minimum_players = min_players
         return obj
 
     def next(self):
-	"""Return the next game mode after this one in the list. Wraps around after hitting bottom."""
-	return Games((self.value + 1) % len(Games))
+        """Return the next game mode after this one in the list. Wraps around after hitting bottom."""
+        return Games((self.value + 1) % len(Games))
 
 class Buttons(Enum):
     middle = 524288

--- a/common.py
+++ b/common.py
@@ -50,45 +50,30 @@ def change_color(color_array, r, g, b):
     color_array[2] = b
 
 class Games(Enum):
-    JoustFFA = 0
-    JoustTeams = 1
-    JoustRandomTeams = 2
-    Traitor = 3
-    WereJoust = 4
-    Zombies = 5
-    Commander = 6
-    Swapper = 7
-    Tournament = 8
-    Ninja = 9
-    Random = 10
+    JoustFFA = (0, 'Joust Free-for-All', 2)
+    JoustTeams = (1, 'Joust Teams', 3)
+    JoustRandomTeams = (2, 'Joust Random Teams', 3)
+    Traitor = (3, 'Traitors', 6)
+    WereJoust = (4, 'Werewolves', 3)
+    Zombies = (5, 'Zombies', 4)
+    Commander = (6, 'Commander', 4)
+    Swapper = (7, 'Swapper', 3)
+    Tournament = (8, 'Tournament', 3)
+    Ninja = (9, 'Ninja Bomb', 2)
+    Random = (10, 'Random', 2)
 
-minimum_players = {
-    Games.JoustFFA.value: 2,
-    Games.JoustTeams.value: 3,
-    Games.JoustRandomTeams.value: 3,
-    Games.Traitor.value: 6,
-    Games.WereJoust.value: 3,
-    Games.Zombies.value: 4,
-    Games.Commander.value: 4,
-    Games.Swapper.value: 3,
-    Games.Tournament.value: 3,
-    Games.Ninja.value: 2,
-    Games.Random.value: 2
-}
+    def __new__(cls, value, pretty_name, min_players):
+        """This odd constructor lets us keep Foo.value as an integer, but also
+	   add some extra properties to each option."""
+        obj = object.__new__(cls)
+        obj._value_ = value
+        obj.pretty_name = pretty_name
+	obj.minimum_players = min_players
+        return obj
 
-game_mode_names = {
-    Games.JoustFFA.value: 'Joust Free-for-All',
-    Games.JoustTeams.value: 'Joust Teams',
-    Games.JoustRandomTeams.value: 'Joust Random Teams',
-    Games.Traitor.value: 'Traitors',
-    Games.WereJoust.value: 'Werewolves',
-    Games.Zombies.value: 'Zombies',
-    Games.Commander.value: 'Commander',
-    Games.Swapper.value: 'Swapper',
-    Games.Tournament.value: 'Tournament',
-    Games.Ninja.value: 'Ninja Bomb',
-    Games.Random.value: 'Random'
-}
+    def next(self):
+	"""Return the next game mode after this one in the list. Wraps around after hitting bottom."""
+	return Games((self.value + 1) % len(Games))
 
 class Buttons(Enum):
     middle = 524288

--- a/joust.py
+++ b/joust.py
@@ -115,12 +115,12 @@ def track_move(move_serial, move_num, game_mode, team, team_num, dead_move, forc
                             flash_lights_timer = 0
                             flash_lights = not flash_lights
                         if flash_lights:
-                            if game_mode == common.Games.WereJoust.value:
+                            if game_mode == common.Games.WereJoust:
                                 move.set_leds(1,1,1)
                             else:
                                 move.set_leds(100,100,100)
                         else:
-                            if game_mode == common.Games.WereJoust.value:
+                            if game_mode == common.Games.WereJoust:
                                 if werewolf_reveal.value == 2 and werewolf:
                                     move.set_leds(255,0,0)
                                 else:
@@ -135,7 +135,7 @@ def track_move(move_serial, move_num, game_mode, team, team_num, dead_move, forc
                             vibrate = False
 
                     else:
-                        if game_mode == common.Games.WereJoust.value:
+                        if game_mode == common.Games.WereJoust:
                             if werewolf_reveal.value == 2 and werewolf:
                                 move.set_leds(255,0,0)
                             else:
@@ -199,7 +199,6 @@ class Joust():
         self.force_move_colors = {}
         self.teams = teams
         self.team_num = 6
-        self.game_mode = game_mode
         self.werewolf_timer = 35
         self.start_timer = time.time()
         self.audio_cue = 0
@@ -214,29 +213,29 @@ class Joust():
         #self.update_status('starting')
         
         self.werewolf_reveal = Value('i', 2)
-        if game_mode == common.Games.JoustFFA.value:
+        if game_mode == common.Games.JoustFFA:
             self.team_num = len(moves)
-        if game_mode == common.Games.JoustRandomTeams.value:
+        if game_mode == common.Games.JoustRandomTeams:
             if len(moves) <= 5:
                 self.team_num = 2
             elif len(moves) in [6,7]:
                 self.team_num = 3
             else: #8 or more
                 self.team_num = 4
-        if game_mode == common.Games.Traitor.value:
+        if game_mode == common.Games.Traitor:
             if len(moves) <= 8:
                 self.team_num = 2
             else: #9 or more
                 self.team_num = 3
             self.werewolf_reveal.value = 0
             
-        if game_mode == common.Games.WereJoust.value:
+        if game_mode == common.Games.WereJoust:
             self.werewolf_reveal.value = 0
             self.team_num = 1
-        if game_mode != common.Games.JoustTeams.value:
+        if game_mode != common.Games.JoustTeams:
             self.generate_random_teams(self.team_num)
 
-        if game_mode == common.Games.WereJoust.value:
+        if game_mode == common.Games.WereJoust:
             #were_num = int((len(moves)+2)/4)
             were_num = int((len(moves)*7)/16)
             if were_num <= 0:
@@ -281,7 +280,7 @@ class Joust():
             serial = random.choice(copy_serials)
             copy_serials.remove(serial)
             random_choice = random.choice(team_pick)
-            if self.game_mode == common.Games.Traitor.value and traitor_pick:
+            if self.game_mode == common.Games.Traitor and traitor_pick:
                 self.teams[serial] = (random_choice * -1) - 1
             else:
                 self.teams[serial] = random_choice
@@ -385,7 +384,7 @@ class Joust():
         self.werewolf_reveal.value = 2
 
     def werewolf_audio_cue(self):
-        if self.game_mode == common.Games.WereJoust.value:
+        if self.game_mode == common.Games.WereJoust:
             #print self.werewolf_timer - (time.time() - self.start_timer)
             if self.werewolf_timer - (time.time() - self.start_timer) <= 30 and self.audio_cue == 0:
                 Audio('audio/Joust/sounds/30 werewolf.wav').start_effect()
@@ -454,10 +453,7 @@ class Joust():
         self.running = False
 
     def end_game_sound(self, winning_team):
-        #if self.game_mode != common.Games.Traitor.value:
-        
-
-        if self.game_mode == common.Games.JoustTeams.value:
+        if self.game_mode == common.Games.JoustTeams:
             if winning_team == 0:
                 team_win = Audio('audio/Joust/sounds/yellow team win.wav')
             if winning_team == 1:
@@ -471,7 +467,7 @@ class Joust():
             if winning_team == 5:
                 team_win = Audio('audio/Joust/sounds/red team win.wav')
             team_win.start_effect()
-        if self.game_mode == common.Games.JoustRandomTeams.value:
+        if self.game_mode == common.Games.JoustRandomTeams:
             if self.team_num == 2:
                 if winning_team == 0:
                     team_win = Audio('audio/Joust/sounds/cyan team win.wav')
@@ -495,7 +491,7 @@ class Joust():
                     team_win = Audio('audio/Joust/sounds/red team win.wav')
             team_win.start_effect()
 
-        if self.game_mode == common.Games.Traitor.value:
+        if self.game_mode == common.Games.Traitor:
             if self.team_num == 2:
                 if winning_team == -1:
                     team_win = Audio('audio/Joust/sounds/traitor win.wav')
@@ -514,7 +510,7 @@ class Joust():
                     team_win = Audio('audio/Joust/sounds/red team win.wav')
             team_win.start_effect()
             
-        if self.game_mode == common.Games.WereJoust.value:
+        if self.game_mode == common.Games.WereJoust:
             if winning_team == -1:
                 team_win = Audio('audio/Joust/sounds/werewolf win.wav')
             else:
@@ -535,10 +531,10 @@ class Joust():
 
     def game_loop(self):
         self.track_moves()
-        if self.game_mode == common.Games.WereJoust.value:
+        if self.game_mode == common.Games.WereJoust:
             self.werewolf_intro()
         self.werewolf_reveal.value = 1
-        if self.game_mode == common.Games.JoustRandomTeams.value:
+        if self.game_mode == common.Games.JoustRandomTeams:
             self.show_team_colors.value = 1
             if self.audo_toggle:
                 Audio('audio/Joust/sounds/teams_form.wav').start_effect_and_wait()
@@ -555,7 +551,7 @@ class Joust():
 
             
         time.sleep(0.8)
-        if self.game_mode == common.Games.WereJoust.value:
+        if self.game_mode == common.Games.WereJoust:
             self.music_speed.value = SLOW_MUSIC_SPEED
             self.audio.change_ratio(self.music_speed.value)
             self.speed_up = False
@@ -568,7 +564,7 @@ class Joust():
                 self.check_command_queue()
                 self.update_status('in_game')
 
-            if self.game_mode != common.Games.WereJoust.value and self.audo_toggle:
+            if self.game_mode != common.Games.WereJoust and self.audo_toggle:
                 self.check_music_speed()
             self.check_end_game()
             if self.audo_toggle:
@@ -589,13 +585,13 @@ class Joust():
 
     def update_status(self,game_status,winning_team=-1):
         data ={'game_status' : game_status,
-               'game_mode' : common.game_mode_names[self.game_mode],
+               'game_mode' : self.game_mode.pretty_name,
                'winning_team' : winning_team}
-        if self.game_mode == common.Games.JoustFFA.value:
+        if self.game_mode == common.Games.JoustFFA:
             data['total_players'] = len(self.move_serials)
             data['remaining_players'] = len([x[0] for x in self.dead_moves.items() if x[1].value==1])
         else:
-            if self.game_mode in [common.Games.WereJoust.value, common.Games.Traitor.value]:
+            if self.game_mode in [common.Games.WereJoust, common.Games.Traitor]:
                 num = self.team_num + 1
                 data['winning_team'] += 1
             else:
@@ -604,7 +600,7 @@ class Joust():
             team_total = [0]*num
             for move in self.move_serials:
                 team = self.teams[move]
-                if self.game_mode in [common.Games.WereJoust.value, common.Games.Traitor.value]:
+                if self.game_mode in [common.Games.WereJoust, common.Games.Traitor]:
                         team += 1 #shift so bad guy team is 0
                         if team < 0:
                             team = 0
@@ -613,7 +609,7 @@ class Joust():
                     team_alive[team] += 1
             team_comp = list(zip(team_total,team_alive))
             data['team_comp'] = team_comp
-        if self.game_mode == common.Games.WereJoust.value:
+        if self.game_mode == common.Games.WereJoust:
             thyme = int(self.werewolf_timer - (time.time() - self.start_timer))
             if thyme < 0:
                 data['time_to_reveal'] = 0

--- a/piaudio.py
+++ b/piaudio.py
@@ -164,5 +164,5 @@ class Audio:
         return pygame.mixer.Sound(self.file).get_length()
 
     def start_effect_and_wait(self):
-	self.start_effect()
-	time.sleep(self.get_length_secs())
+        self.start_effect()
+        time.sleep(self.get_length_secs())

--- a/piparty.py
+++ b/piparty.py
@@ -405,7 +405,7 @@ class Menu():
                 if self.game_mode == common.Games.WereJoust:
                     self.game_mode = self.game_mode.next()
             for opt in self.move_opts.values():
-                opt[Opts.game_mode.value] = self.game_mode
+                opt[Opts.game_mode.value] = self.game_mode.value
             if self.audio_toggle:
                 self.game_mode_announcement()
 

--- a/piparty.py
+++ b/piparty.py
@@ -10,9 +10,6 @@ from webui import start_web
 TEAM_NUM = 6
 TEAM_COLORS = common.generate_colors(TEAM_NUM)
 
-#the number of game modes
-GAME_MODES = 11
-
 SENSITIVITY_MODES = 3
 
 class Opts(Enum):
@@ -70,7 +67,7 @@ def track_move(serial, move_num, move_opts, force_color, battery, dead_count):
     while True:
         time.sleep(0.01)
         if move.poll():
-            game_mode = move_opts[Opts.game_mode.value]
+            game_mode = common.Games(move_opts[Opts.game_mode.value])
             move_button = move.get_buttons()
             if move_opts[Opts.alive.value] == Alive.off.value:
                 if move_button == Buttons.sync.value:
@@ -110,7 +107,7 @@ def track_move(serial, move_num, move_opts, force_color, battery, dead_count):
                     
                 #custom team mode is the only game mode that
                 #can't be added to con mode
-                elif game_mode == common.Games.JoustTeams.value:
+                elif game_mode == common.Games.JoustTeams:
                     if move_opts[Opts.team.value] >= TEAM_NUM:
                         move_opts[Opts.team.value] = 0
                     move.set_leds(*TEAM_COLORS[move_opts[Opts.team.value]])
@@ -124,16 +121,16 @@ def track_move(serial, move_num, move_opts, force_color, battery, dead_count):
                 elif sum(force_color) != 0:
                     move.set_leds(*force_color)
 
-                elif game_mode == common.Games.JoustFFA.value:
+                elif game_mode == common.Games.JoustFFA:
                     move.set_leds(255,255,255)
                             
                             
-                elif game_mode == common.Games.JoustRandomTeams.value:
+                elif game_mode == common.Games.JoustRandomTeams:
                     color = time.time()/10%1
                     color = common.hsv2rgb(color, 1, 1)
                     move.set_leds(*color)
 
-                elif game_mode == common.Games.Traitor.value:
+                elif game_mode == common.Games.Traitor:
                     if move_num%4 == 2 and time.time()/3%1 < .15:
                         move.set_leds(200,0,0)
                     else:
@@ -141,28 +138,28 @@ def track_move(serial, move_num, move_opts, force_color, battery, dead_count):
                         color = common.hsv2rgb(color, 1, 1)
                         move.set_leds(*color)
 
-                elif game_mode == common.Games.WereJoust.value:
+                elif game_mode == common.Games.WereJoust:
                     if move_num <= 0:
                         move.set_leds(150,0,0)
                     else:
                         move.set_leds(200,200,200)
 
-                elif game_mode == common.Games.Zombies.value:
+                elif game_mode == common.Games.Zombies:
                         move.set_leds(50,150,50)
 
-                elif game_mode == common.Games.Commander.value:
+                elif game_mode == common.Games.Commander:
                     if move_num % 2 == 0:
                         move.set_leds(150,0,0)
                     else:
                         move.set_leds(0,0,150)
 
-                elif game_mode == common.Games.Swapper.value:
+                elif game_mode == common.Games.Swapper:
                     if (time.time()/5 + random_color)%1 > 0.5:
                         move.set_leds(150,0,0)
                     else:
                         move.set_leds(0,0,150)
 
-                elif game_mode == common.Games.Tournament.value:
+                elif game_mode == common.Games.Tournament:
                     if move_num <= 0:
                         color = time.time()/10%1
                         color = common.hsv2rgb(color, 1, 1)
@@ -171,14 +168,14 @@ def track_move(serial, move_num, move_opts, force_color, battery, dead_count):
                         move.set_leds(200,200,200)
 
 
-                elif game_mode == common.Games.Ninja.value:
+                elif game_mode == common.Games.Ninja:
                     if move_num <= 0:
                         move.set_leds(random.randrange(100, 200),0,0)
                     else:
                         move.set_leds(200,200,200)
 
 
-                elif game_mode == common.Games.Random.value:
+                elif game_mode == common.Games.Random:
                     
                     if move_button == Buttons.middle.value:
                         move_opts[Opts.random_start.value] = Alive.off.value
@@ -238,12 +235,11 @@ class Menu():
             self.sensitivity = int(config['GENERAL']['sensitivity'])
             self.instructions = config.getboolean("GENERAL","instructions")
             self.con_games = []
-            for i in range(len(common.game_mode_names)):
-                mode = common.game_mode_names[i]
-                if config.getboolean("CONGAMES",mode):
-                    self.con_games.append(i)
+            for game in common.Games:
+                if config.getboolean("CONGAMES", game.pretty_name):
+                    self.con_games.append(game)
             if self.con_games == []:
-                self.con_games = [0]
+                self.con_games = [common.Games.JoustFFA]
 
         self.enforce_minimum = True
         self.move_can_be_admin = True
@@ -263,8 +259,8 @@ class Menu():
         self.paired_moves = []
         self.move_opts = {}
         self.teams = {}
-        self.game_mode = common.Games.Random.value
-        self.old_game_mode = common.Games.Random.value
+        self.game_mode = common.Games.Random
+        self.old_game_mode = common.Games.Random
         self.pair = pair.Pair()
 
         self.command_queue = command_queue
@@ -345,7 +341,7 @@ class Menu():
                     opts[Opts.team.value] = self.teams[move_serial]
                 if move_serial in self.out_moves:
                     opts[Opts.alive.value] = self.out_moves[move_serial]
-                opts[Opts.game_mode.value] = self.game_mode
+                opts[Opts.game_mode.value] = self.game_mode.value
                 
                 #now start tracking the move controller
                 proc = Process(target=track_move, args=(move_serial, move_num, opts, color, self.show_battery, self.dead_count))
@@ -357,27 +353,27 @@ class Menu():
 
 
     def game_mode_announcement(self):
-        if self.game_mode == common.Games.JoustFFA.value:
+        if self.game_mode == common.Games.JoustFFA:
             Audio('audio/Menu/menu Joust FFA.wav').start_effect()
-        if self.game_mode == common.Games.JoustTeams.value:
+        if self.game_mode == common.Games.JoustTeams:
             Audio('audio/Menu/menu Joust Teams.wav').start_effect()
-        if self.game_mode == common.Games.JoustRandomTeams.value:
+        if self.game_mode == common.Games.JoustRandomTeams:
             Audio('audio/Menu/menu Joust Random Teams.wav').start_effect()
-        if self.game_mode == common.Games.Traitor.value:
+        if self.game_mode == common.Games.Traitor:
             Audio('audio/Menu/menu Traitor.wav').start_effect()
-        if self.game_mode == common.Games.WereJoust.value:
+        if self.game_mode == common.Games.WereJoust:
             Audio('audio/Menu/menu werewolfs.wav').start_effect()
-        if self.game_mode == common.Games.Zombies.value:
+        if self.game_mode == common.Games.Zombies:
             Audio('audio/Menu/menu Zombies.wav').start_effect()
-        if self.game_mode == common.Games.Commander.value:
+        if self.game_mode == common.Games.Commander:
             Audio('audio/Menu/menu Commander.wav').start_effect()
-        if self.game_mode == common.Games.Swapper.value:
+        if self.game_mode == common.Games.Swapper:
             Audio('audio/Menu/menu Swapper.wav').start_effect()
-        if self.game_mode == common.Games.Tournament.value:
+        if self.game_mode == common.Games.Tournament:
             Audio('audio/Menu/menu Tournament.wav').start_effect()
-        if self.game_mode == common.Games.Ninja.value:
+        if self.game_mode == common.Games.Ninja:
             Audio('audio/Menu/menu ninjabomb.wav').start_effect()
-        if self.game_mode == common.Games.Random.value:
+        if self.game_mode == common.Games.Random:
             Audio('audio/Menu/menu Random.wav').start_effect()
 
     def check_change_mode(self):
@@ -399,12 +395,12 @@ class Menu():
             change_mode = True
 
         if change_mode:
-            self.game_mode = (self.game_mode + 1) %  GAME_MODES
+            self.game_mode = self.game_mode.next()
             if not self.audio_toggle:
-                if self.game_mode == common.Games.Commander.value:
-                    self.game_mode = (self.game_mode + 1) %  GAME_MODES
-                if self.game_mode == common.Games.WereJoust.value:
-                    self.game_mode = (self.game_mode + 1) %  GAME_MODES
+                if self.game_mode == common.Games.Commander:
+                    self.game_mode = self.game_mode.next()
+                if self.game_mode == common.Games.WereJoust:
+                    self.game_mode = self.game_mode.next()
             for opt in self.move_opts.values():
                 opt[Opts.game_mode.value] = self.game_mode
             if self.audio_toggle:
@@ -467,7 +463,7 @@ class Menu():
                 self.update_settings_file()
                 
             #no admin colors in con custom teams mode
-            if self.game_mode == common.Games.JoustTeams.value or self.game_mode == common.Games.Random.value:
+            if self.game_mode == common.Games.JoustTeams or self.game_mode == common.Games.Random:
                 self.force_color[self.admin_move][0] = 0
                 self.force_color[self.admin_move][1] = 0
                 self.force_color[self.admin_move][2] = 0
@@ -514,11 +510,10 @@ class Menu():
         self.audio_toggle = 'audio' in admin_info.keys()
 
         selected_games = admin_info.getlist('random_modes')
-        gmn = common.game_mode_names
-        self.con_games = [i for i in range(len(gmn)) if gmn[i] in selected_games]
+        self.con_games = [ game for game in common.Games if game.pretty_name in selected_games]
         #print(self.con_games)
         if self.con_games == []:
-            self.con_games = [common.Games.JoustFFA.value]
+            self.con_games = [common.Games.JoustFFA]
 
         self.update_settings_file()
 
@@ -529,8 +524,7 @@ class Menu():
             'instructions' : str(self.instructions),
             'audio': str(self.audio_toggle)
         }
-        gmn = common.game_mode_names
-        config['CONGAMES'] = {gmn[i]:i in self.con_games for i in range(len(gmn))}
+        config['CONGAMES'] = { game.pretty_name : game in self.con_games for game in common.Games }
         with open('joustconfig.ini','w') as ini_file:
             config.write(ini_file)
 
@@ -538,7 +532,7 @@ class Menu():
         self.audio_toggle = True
         self.sensitivity = Sensitivity.mid.value
         self.instructions = False
-        self.con_games = [common.Games.JoustFFA.value]
+        self.con_games = [common.Games.JoustFFA]
         self.update_settings_file()
         os.system('chmod 666 joustconfig.ini') #damn root
 
@@ -553,7 +547,7 @@ class Menu():
 
     def update_status(self,game_status):
         data ={'game_status' : game_status,
-               'game_mode' : common.game_mode_names[self.game_mode],
+               'game_mode' : self.game_mode.pretty_name,
                'move_count' : self.move_count,
                'alive_count' : self.move_count - self.dead_count.value,
                'ticker': self.i,
@@ -562,7 +556,7 @@ class Menu():
                'sensitivity': self.sensitivity,
                'audio': self.audio_toggle,
                'enforce_minimum': self.enforce_minimum,
-               'con_games': [common.game_mode_names[i] for i in self.con_games]}
+               'con_games': [ game.pretty_name for game in self.con_games]}
         self.status_ns.status_dict = data
 
         battery_status = {}
@@ -579,7 +573,7 @@ class Menu():
             proc.join()
             
     def check_start_game(self):
-        if self.game_mode == common.Games.Random.value:
+        if self.game_mode == common.Games.Random:
             self.exclude_out_moves()
             start_game = True
             for serial in self.move_opts.keys():
@@ -606,23 +600,23 @@ class Menu():
                 self.start_game()
 
     def play_random_instructions(self):
-        if self.game_mode == common.Games.JoustFFA.value:
+        if self.game_mode == common.Games.JoustFFA:
             Audio('audio/Menu/FFA-instructions.wav').start_effect_and_wait()
-        if self.game_mode == common.Games.JoustRandomTeams.value:
+        if self.game_mode == common.Games.JoustRandomTeams:
             Audio('audio/Menu/Teams-instructions.wav').start_effect_and_wait()
-        if self.game_mode == common.Games.Traitor.value:
+        if self.game_mode == common.Games.Traitor:
             Audio('audio/Menu/Traitor-instructions.wav').start_effect_and_wait()
-        if self.game_mode == common.Games.WereJoust.value:
+        if self.game_mode == common.Games.WereJoust:
             Audio('audio/Menu/werewolf-instructions.wav').start_effect_and_wait()
-        if self.game_mode == common.Games.Zombies.value:
+        if self.game_mode == common.Games.Zombies:
             Audio('audio/Menu/zombie-instructions.wav').start_effect_and_wait()
-        if self.game_mode == common.Games.Commander.value:
+        if self.game_mode == common.Games.Commander:
             Audio('audio/Menu/commander-instructions.wav').start_effect_and_wait()
-        if self.game_mode == common.Games.Ninja.value:
+        if self.game_mode == common.Games.Ninja:
             Audio('audio/Menu/Ninjabomb-instructions.wav').start_effect_and_wait()
-        if self.game_mode == common.Games.Swapper.value:
+        if self.game_mode == common.Games.Swapper:
             Audio('audio/Menu/Swapper-instructions.wav').start_effect_and_wait()
-        if self.game_mode == common.Games.Tournament.value:
+        if self.game_mode == common.Games.Tournament:
             Audio('audio/Menu/Tournament-instructions.wav').start_effect_and_wait()
 
 
@@ -634,7 +628,7 @@ class Menu():
         self.teams = {serial: self.move_opts[serial][Opts.team.value] for serial in self.tracked_moves.keys() if self.out_moves[serial] == Alive.on.value}
         game_moves = [move.get_serial() for move in self.moves if self.out_moves[move.get_serial()] == Alive.on.value]
 
-        if len(game_moves) < common.minimum_players[self.game_mode] and self.enforce_minimum:
+        if len(game_moves) < self.game_mode.minimum_players and self.enforce_minimum:
             Audio('audio/Menu/notenoughplayers.wav').start_effect()
             self.tracked_moves = {}
             return
@@ -642,11 +636,11 @@ class Menu():
 
         if random_mode:
             if self.enforce_minimum:
-                good_con_games = [i for i in self.con_games if common.minimum_players[i] <= len(game_moves)]
+                good_con_games = [game for game in self.con_games if game.minimum_players <= len(game_moves)]
             else:
                 good_con_games = self.con_games
             if len(good_con_games) == 0:
-                selected_game = 0 #force Joust FFA
+                selected_game = common.Games.JoustFFA  #force Joust FFA
             elif len(good_con_games) == 1:
                 selected_game = good_con_games[0]
             else:
@@ -666,19 +660,19 @@ class Menu():
         if self.instructions and self.audio_toggle:
             self.play_random_instructions()
         
-        if self.game_mode == common.Games.Zombies.value:
+        if self.game_mode == common.Games.Zombies:
             zombie.Zombie(game_moves, self.sensitivity, self.command_queue, self.status_ns, self.audio_toggle, self.zombie_music)
             self.tracked_moves = {}
-        elif self.game_mode == common.Games.Commander.value:
+        elif self.game_mode == common.Games.Commander:
             commander.Commander(game_moves, self.sensitivity, self.command_queue, self.status_ns, self.commander_music)
             self.tracked_moves = {}
-        elif self.game_mode == common.Games.Ninja.value:
+        elif self.game_mode == common.Games.Ninja:
             speed_bomb.Bomb(game_moves, self.command_queue, self.status_ns, self.audio_toggle, self.commander_music)
             self.tracked_moves = {}
-        elif self.game_mode == common.Games.Swapper.value:
+        elif self.game_mode == common.Games.Swapper:
             swapper.Swapper(game_moves, self.sensitivity, self.command_queue, self.status_ns, self.audio_toggle, self.joust_music)
             self.tracked_moves = {}
-        elif self.game_mode == common.Games.Tournament.value:
+        elif self.game_mode == common.Games.Tournament:
             tournament.Tournament(game_moves, self.sensitivity, self.command_queue, self.status_ns, self.audio_toggle, self.joust_music)
             self.tracked_moves = {}
         else:
@@ -686,7 +680,7 @@ class Menu():
             joust.Joust(self.game_mode, game_moves, self.teams, self.sensitivity, self.command_queue, self.status_ns, self.audio_toggle,self.joust_music)
             self.tracked_moves = {}
         if random_mode:
-            self.game_mode = common.Games.Random.value
+            self.game_mode = common.Games.Random
             if self.instructions:
                 if self.audio_toggle:
                     Audio('audio/Menu/tradeoff2.wav').start_effect_and_wait()

--- a/piparty.py
+++ b/piparty.py
@@ -236,6 +236,9 @@ class Menu():
             self.instructions = config.getboolean("GENERAL","instructions")
             self.con_games = []
             for game in common.Games:
+                # We should probably store .name or .value in the config,
+                # so it is not affected by localization or whatnot, but
+                # it would break existing configs.
                 if config.getboolean("CONGAMES", game.pretty_name):
                     self.con_games.append(game)
             if self.con_games == []:

--- a/webui.py
+++ b/webui.py
@@ -16,14 +16,15 @@ class MultiCheckboxField(SelectMultipleField):
     widget = widgets.ListWidget(prefix_label=True)
     option_widget = widgets.CheckboxInput()
 
-gmn = common.game_mode_names
 
 class SettingsForm(Form):
     move_admin = BooleanField('Allow Move to change settings')
     instructions = BooleanField('Play instructions before game start')
     audio = BooleanField('Play audio')
     sensitivity = SelectField('Move sensitivity',choices=[(0,'Slow'),(1,'Medium'),(2,'Fast')],coerce=int)
-    random_modes = MultiCheckboxField('Random Modes',choices=[(gmn[i],gmn[i]) for i in range(len(gmn)) if gmn[i] not in ["Random","Joust Teams"]])
+
+    mode_options = [ game for game in common.Games if game not in [common.Games.Random, common.Games.JoustTeams]]
+    random_modes = MultiCheckboxField('Random Modes',choices=[(game.pretty_name, game.pretty_name) for game in mode_options])
 
 class WebUI():
     def __init__(self, command_queue=Queue(), ns=Manager().Namespace()):


### PR DESCRIPTION
Switches all uses of common.Game to a more idiomatic style.
We directly use the enum members instead of their integer values. This means less typing, and less possible confusion between enum types. .value is still used when serializing data (for IPC and the config file). Additionally, folds the 'game_mode_names' and 'minimum_players' tables into attributes on the enum.

Note that ideally we would use .name (or even .value) in the config file, as it is less likely to change (for example due to localization), but for now we don't want to break people's configs.

Tested by firing up the game, changing game modes a few times, and playing a 2player game of FFA.