### PR TITLE
Rewrite audio resampling loop.

### DIFF
--- a/joust.py
+++ b/joust.py
@@ -365,14 +365,12 @@ class Joust():
         if time.time() > self.change_time and time.time() < self.change_time + INTERVAL_CHANGE:
             self.change_music_speed(self.speed_up)
             self.currently_changing = True
-            self.audio.change_chunk_size(True)
         elif time.time() >= self.change_time + INTERVAL_CHANGE and self.currently_changing:
             self.music_speed.value = SLOW_MUSIC_SPEED if self.speed_up else FAST_MUSIC_SPEED
             self.speed_up =  not self.speed_up
             self.change_time = self.get_change_time(speed_up = self.speed_up)
             self.audio.change_ratio(self.music_speed.value)
             self.currently_changing = False
-            self.audio.change_chunk_size(False)
 
     def get_real_team(self, team):
         if team < 0:

--- a/tournament.py
+++ b/tournament.py
@@ -327,14 +327,12 @@ class Tournament():
         if time.time() > self.change_time and time.time() < self.change_time + INTERVAL_CHANGE:
             self.change_music_speed(self.speed_up)
             self.currently_changing = True
-            self.audio.change_chunk_size(True)
         elif time.time() >= self.change_time + INTERVAL_CHANGE and self.currently_changing:
             self.music_speed.value = SLOW_MUSIC_SPEED if self.speed_up else FAST_MUSIC_SPEED
             self.speed_up =  not self.speed_up
             self.change_time = self.get_change_time(speed_up = self.speed_up)
             self.audio.change_ratio(self.music_speed.value)
             self.currently_changing = False
-            self.audio.change_chunk_size(False)
 
 
     def check_matches(self):


### PR DESCRIPTION
 * We use generators to separate reading/resampling/writing logic.
 * Use a larger write buffer size to reduce clicking/popping.
 * Round the desired number of samples down to the nearest multiple of 32 for improved FFT performance. This dropped the amount of CPU used by the music process by about 50-60%.
 * Don't bother re-opening the audio file or output device every time the track loops.
 * Get rid of "chunk_size" parameter. We always read fixed-size chunks from the wave file, and lump them together into fixed-size chunks on output, so it is no longer necessary.