### PR TITLE
Switch to installing most python deps in a virtualenv.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ You can now disconnect the hdmi cable and run JoustMania in headless mode. Joust
 
 Update Joust Mania
 ---------------------------
-You can update Joust Mania by doing a `git pull` in the main directory and rebooting the pi.
+You can update Joust Mania by doing a `git pull` in the main directory and running
+```
+./setup.sh
+```
 
 
 Pairing controllers

--- a/conf/supervisor/conf.d/joust.conf
+++ b/conf/supervisor/conf.d/joust.conf
@@ -1,6 +1,6 @@
 [program:joustmania]
 command=/home/pi/JoustMania/joust.sh
-user=pi
+user=root
 directory=/home/pi/JoustMania/
 autorestart=true
 startretries=1000

--- a/joust.sh
+++ b/joust.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ $UID -ne 0 ]; then
+  echo "Not root. Using sudo."
+  exec sudo $0
+fi
+
 export HOME="/home/pi/JoustMania"
 export PYTHONPATH="/home/pi/psmoveapi/build/"
-sudo /usr/bin/python3.6 /home/pi/JoustMania/piparty.py
+/home/pi/JoustMania/venv/bin/python3.6 /home/pi/JoustMania/piparty.py

--- a/setup.sh
+++ b/setup.sh
@@ -6,8 +6,9 @@ export DEBIAN_FRONTEND=noninteractive
 #update OS
 sudo cp -v conf/sources.list /etc/apt/sources.list || exit -1
 sudo cp -v conf/apt.conf /etc/apt/apt.conf.d/10joustmania-conf || exit -1
-sudo apt-get update -y
-sudo apt-get dist-upgrade -y
+sudo apt-get update -y || exit -1
+sudo apt-get upgrade -y || exit -1
+sudo apt-get dist-upgrade -y || exit -1
 cd /home/pi
 
 #TODO: remove pyaudio and dependencies
@@ -16,25 +17,33 @@ sudo apt-get install -y  \
     python3.6 python3.6-dev python3-pip \
     python3-pkg-resources python3-setuptools libdpkg-perl \
     libsdl1.2-dev libsdl-mixer1.2-dev libsdl-sound1.2-dev \
-    libportmidi-dev \
+    libportmidi-dev portaudio19-dev \
     libsdl-image1.2-dev libsdl-ttf2.0-dev \
-    bluez python3-pyaudio \
-    supervisor \
-    cmake \
+    libblas-dev liblapack-dev \
+    bluez supervisor cmake ffmpeg \
     libudev-dev swig libbluetooth-dev \
     alsa-utils alsa-tools libasound2-dev || exit -1
-
-sudo apt-get remove -y python3-pygame
-sudo apt-get install -y -t buster libasound2-dev libasound2 python3-numpy python3-scipy
-sudo python3.6 -m pip install --upgrade virtualenv || exit -1
-sudo python3.6 -m pip install psutil flask Flask-WTF pyalsaaudio pydub pygame || exit -1
 
 #install components for psmoveapi
 sudo apt-get install -y \
     build-essential \
     libv4l-dev libopencv-dev \
     libudev-dev libbluetooth-dev \
-    python3-dev swig3.0 || exit -1
+    python3.6-dev swig3.0 || exit -1
+
+
+
+VENV=$HOME/JoustMania/venv
+# We install nearly all python deps in the virtualenv to avoid concflicts with system, except
+# numpy and scipy because they take forever to build.
+sudo apt-get install -y -t buster libasound2-dev libasound2 python3-numpy python3-scipy
+sudo python3.6 -m pip install --upgrade virtualenv || exit -1
+
+# Rebuilding this is pretty cheap, so just do it every time.
+rm -rf $VENV
+/usr/bin/python3.6 -m virtualenv --system-site-packages $VENV || exit -1
+PYTHON=$VENV/bin/python3.6
+$PYTHON -m pip install --ignore-installed psutil flask Flask-WTF pyalsaaudio pydub pygame pyaudio || exit -1
 
 #install psmoveapi
 git clone --recursive git://github.com/thp/psmoveapi.git
@@ -68,4 +77,5 @@ OLD='env_reset'
 NEW='env_keep += "PYTHONPATH"'
 sudo sed -i -e "s/$OLD/$NEW/g" /etc/sudoers
 
-sudo reboot
+# Pause a second before rebooting so we can see all the output from this script.
+(sleep 1; sudo reboot) &


### PR DESCRIPTION
Using a virtualenv will hopefully minimize conflicts with system libraries. We notably do not install numpy and scipy like this, as they take forever to compile. We also switch the supervisor configuration to run directly as root instead of using sudo, as the latter makes it impossible for supervisor to kill the task at shutdown.