### PR TITLE
Adds support for changing paces to experiental FFA implementation.

### DIFF
--- a/audio_tool.py
+++ b/audio_tool.py
@@ -1,0 +1,30 @@
+import asyncio
+import sys
+
+sys.path.append('/home/pi/psmoveapi/build')
+
+import piaudio
+
+
+def Main():
+    music = piaudio.Music('audio/Joust/music/classical.wav')
+    music.start_audio_loop()
+
+    loop = asyncio.get_event_loop()
+    print("Enter a FP number:")
+    async def ProcessInput():
+        while True:
+            line = await loop.run_in_executor(None, sys.stdin.readline)
+            try:
+                ratio = float(line)
+            except ValueError:
+                print("invalid value: %s" % line)
+            await music.transition_ratio(ratio)
+            print("OK.")
+            
+    loop.run_until_complete(ProcessInput())
+    music.stop_audio()
+
+
+if __name__ == '__main__':
+    Main()

--- a/games/ffa.py
+++ b/games/ffa.py
@@ -3,17 +3,19 @@ import asyncio
 import time
 
 import common
-from player import Player, PlayerCollection
+import pacemanager
+from player import Player, PlayerCollection, EventType
 
 # Hertz
 UPDATE_FREQUENCY=30
 
-# TODO: These are placeholder values.
-# We can't take the values from joust.py, since those are compared to the sum of the
-# three accelerometer dimensions, whereas we compute the magnitude of the acceleration
-# vector.
-DEATH_THRESHOLD=7
-WARN_THRESHOLD=2
+# Values are (weight, min_duration, max_duration)
+PACE_TIMING = {
+    common.MEDIUM_PACE: (1.0, 10, 23),
+    common.FAST_PACE: (1.0, 5, 15),
+}
+
+INITIAL_PACE_DURATION=18
 
 class FreeForAll:
     ## Note, the "Player" objects should probably get created (and assigned colors) by the core game code, not here.
@@ -23,6 +25,7 @@ class FreeForAll:
             player.set_player_color(color)
         self.players = PlayerCollection(players)
         self.music = music
+        self.pace_ = common.MEDIUM_PACE
         self.rainbow_duration_ = 6
 
     def has_winner_(self):
@@ -30,24 +33,48 @@ class FreeForAll:
             raise ValueError("Can't have zero players!")
         return len(self.players.active_players) == 1
 
+    def build_pace_manager_(self):
+        pm = pacemanager.PaceManager(self.pace_change_callback_, self.pace_, INITIAL_PACE_DURATION)
+        for pace, timing in PACE_TIMING.items():
+            pm.add_or_update_pace(pace, *timing)
+        return pm
+
+    def pace_change_callback_(self, new_pace):
+        @common.async_print_exceptions
+        async def change_pace():
+            print("Changing pace to %s..." % new_pace)
+            transition_future = self.music.transition_ratio(new_pace.tempo)
+            # If we're slowing down the pace, give players a grace period to respond.
+            if new_pace.tempo < self.pace_.tempo:
+                await transition_future
+                await asyncio.sleep(0.5)
+            self.pace_ = new_pace
+            print(".... Done.")
+        asyncio.ensure_future(change_pace())
+
     def game_tick_(self):
         """Implements a game tick.
            Polls controllers for input, and issues warnings/deaths to players."""
         # Make a copy of the active players, as we may modify it during iteration.
-        for player, state in self.players.active_player_events():
-            if state.acceleration_magnitude > DEATH_THRESHOLD:
-                self.players.kill_player(player)
+        pace = self.pace_
+        for event in self.players.active_player_events(EventType.ACCELEROMETER):
+            if event.acceleration_magnitude > pace.death_threshold:
+                self.players.kill_player(event.player)
 
                 # Cut out early if we have a winner, so we don't accidentally kill all remaining players.
                 if self.has_winner_():
                     break
-            elif state.acceleration_magnitude > WARN_THRESHOLD:
-                player.warn()
+            elif event.acceleration_magnitude > pace.warn_threshold:
+                event.player.warn()
 
     async def run(self):
         """Main loop for this game."""
         # TODO: Countdown/Intro.
         self.music.start_audio_loop()
+
+        # TODO: Vary pace with player deaths.
+        pm = self.build_pace_manager_()
+        pm.start()
         try:
             while not self.has_winner_():
                 self.game_tick_()
@@ -57,6 +84,7 @@ class FreeForAll:
             winner = list(self.players.active_players)[0]
             await winner.show_rainbow(self.rainbow_duration_)
         finally:
+            pm.stop()
             self.music.stop_audio()
             self.players.cancel_effects()
 

--- a/pacemanager.py
+++ b/pacemanager.py
@@ -1,0 +1,72 @@
+import asyncio
+import collections
+import random
+import typing
+
+import common
+
+PaceSettings_ = collections.namedtuple('PaceSettings_', ['weight', 'min_duration', 'max_duration'])
+
+
+class PaceManager:
+    """Manages transitions between game paces, and notifies users of changes via a callback.
+       The game starts out in the initial pace, then switches pace according to parameters
+       passed in. The actual pace is treated as an opaque object -- this class does not care
+       what the pace represents, it is just in charge of timing transitions.
+       Sample usage:
+
+        pm = PaceManager(cb, pace1, 10)
+        pm.add_or_update_pace(pace2, 1.0, 10, 20)
+        pm.add_or_update_pace(pace3, 2.0, 5, 10)
+        pm.start()
+        ....
+        pm.stop()
+
+       Here, we start off with pace1 for 10 seconds. After that, we will switch to either pace2, or pace3,
+       with pace3 being twice as likely. If pace2 is chosen, it will be kept for 10-20 seconds. pace3 will
+       be kept for 5-10 seconds.
+    """
+
+    def __init__(self, callback, initial_pace, initial_pace_time: float, rng=random.uniform):
+        self.initial_pace_ = initial_pace
+        self.initial_pace_time_ = initial_pace_time
+        self.available_paces_ = {}
+        self.task_ = None
+        self.rng_ = rng
+        self.callback_ = callback
+
+    def add_or_update_pace(self, pace, weight: float, min_duration: float, max_duration: float):
+        self.available_paces_[pace] = PaceSettings_(weight, min_duration, max_duration)
+
+    def start(self):
+        self.task_ = asyncio.ensure_future(self.run_())
+        return self.task_
+
+    def stop(self):
+        self.task_.cancel()
+
+    def set_pace_(self, pace):
+        self.callback_(pace)
+
+    def choose_new_pace_(self, old_pace) -> typing.Tuple[object, float]:
+        if len(self.available_paces_) == 0:
+            raise RuntimeError("No paces registered.")
+        candidates = self.available_paces_
+        total_weight = sum([ params.weight for params in candidates.values() ])
+        index = self.rng_(0, total_weight)
+        cumulative_weight = 0
+        for pace, params in candidates.items():
+            cumulative_weight += params.weight
+            if cumulative_weight >= index:
+                return pace, self.rng_(params.min_duration, params.max_duration)
+        raise ValueError("Couldn't find pace with index %s/%s!?" % (index, total_weight))
+
+    @common.async_print_exceptions
+    async def run_(self):
+        await asyncio.sleep(self.initial_pace_time_)
+
+        pace = self.initial_pace_
+        while True:
+            pace, duration_secs = self.choose_new_pace_(pace)
+            self.set_pace_(pace)
+            await asyncio.sleep(duration_secs)

--- a/pacemanager_test.py
+++ b/pacemanager_test.py
@@ -1,0 +1,65 @@
+import asyncio
+import collections
+import time
+import unittest
+
+import pacemanager
+
+PACE1 = object()
+PACE2 = object()
+PACE3 = object()
+
+class PaceManagerTest(unittest.TestCase):
+    def assertPrettyClose(self, a, b, error=0.1):
+        self.assertGreater(error, abs(a - b))
+
+    def test_distribution(self):
+        pm = pacemanager.PaceManager(lambda x: True, PACE1, 5)
+        pm.add_or_update_pace(PACE1, 1.0, 1, 2)
+
+        # Test to make sure we don't double up on PACE2
+        pm.add_or_update_pace(PACE2, 1.0, 1, 2)
+        pm.add_or_update_pace(PACE2, 1.0, 1, 2)
+        pm.add_or_update_pace(PACE3, 2.0, 1, 2)
+
+        results = collections.defaultdict(int)
+        num_trials = 1000
+        for i in range(num_trials):
+            pace, duration = pm.choose_new_pace_(PACE1)
+            results[pace] += 1
+            self.assertLessEqual(1, duration)
+            self.assertGreater(2, duration)
+
+        self.assertEqual(3, len(results))
+        self.assertPrettyClose(1/4, results[PACE1]/num_trials)
+        self.assertPrettyClose(1/4, results[PACE2]/num_trials)
+        self.assertPrettyClose(1/2, results[PACE3]/num_trials)
+
+    def test_async(self):
+        Entry = collections.namedtuple('Entry', ['pace', 'time'])
+        results = []
+        begin = time.time()
+        def UpdatePace(pace):
+            results.append(Entry(pace, time.time() - begin))
+        uniform = lambda a, b: a
+
+        DELTA = 0.1
+        pm = pacemanager.PaceManager(UpdatePace, PACE1, DELTA, rng=uniform)
+        pm.add_or_update_pace(PACE1, 1.0, DELTA, 1 + DELTA)
+        pm.add_or_update_pace(PACE2, 1.0, DELTA, 1 + DELTA)
+        loop = asyncio.get_event_loop()
+        try:
+            # This should get us 4 events.
+            timeout = DELTA * 4.1
+            loop.run_until_complete(asyncio.wait_for(pm.start(), timeout=timeout))
+        except asyncio.TimeoutError:
+            pass
+
+        # We should have registered a new pace 4 times, about DELTA seconds apart.
+        self.assertEqual(4, len(results))
+        for i in range(4):
+            self.assertPrettyClose(results[i].time, DELTA * (i+1))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/player.py
+++ b/player.py
@@ -1,5 +1,7 @@
+import abc
 import asyncio
 import collections
+import enum
 import functools
 import itertools
 import math
@@ -12,18 +14,82 @@ NUM_WARNING_FLASHES=5
 WARNING_FLASH_DURATION=0.1
 RAINBOW_PHASE_DURATION=0.1
 
+class EventType(enum.Flag):
+    ACCELEROMETER = enum.auto()
+    BUTTON_DOWN = enum.auto()
+    BUTTON_UP = enum.auto()
+    # TODO: Add trigger events
+
+class ControllerEvent(abc.ABC):
+    __slots__ = ['player']
+
+    @abc.abstractproperty
+    def type(self): raise NotImplemented()
+
+class AccelerometerEvent(ControllerEvent):
+    """Base class for controller events."""
+    __slots__ = ['acceleration']
+
+    def __init__(self, acceleration):
+        self.acceleration = acceleration
+
+    @property
+    def type(self):
+        return EventType.ACCELEROMETER
+
+    @property
+    def acceleration_magnitude(self):
+        return math.sqrt(sum([ v*v for v in self.acceleration ]))
+
+class ButtonDownEvent(ControllerEvent):
+    """Sent when a player first presses a button."""
+    __slots__ = ['button']
+
+    def __init__(self, button: common.Button):
+        self.button = button
+
+    @property
+    def type(self):
+        return EventType.BUTTON_DOWN
+
+class ButtonUpEvent(ControllerEvent):
+    """Sent when a player first releases a button."""
+    __slots__ = ['button']
+
+    def __init__(self, player, button: common.Button):
+        super().__init__(player)
+        self.button = button
+
+    @property
+    def type(self):
+        return EventType.BUTTON_UP
+
+
 class ControllerState:
     """The state of inputs on a controller at one point in time."""
     __slots__ = ['buttons', 'trigger', 'acceleration']
 
     def __init__(self, move):
         self.buttons = common.Button(move.get_buttons())
-        self.trigger = move.get_trigger() / 100
+        self.trigger = move.get_trigger()
         self.acceleration = move.get_accelerometer_frame(psmove.Frame_SecondHalf)
 
     @property
     def acceleration_magnitude(self):
         return math.sqrt(sum([ v*v for v in self.acceleration ]))
+
+    def get_events_from_state_diff(self, prev_state):
+        # Is this ever false?
+        if prev_state.acceleration != self.acceleration:
+            yield AccelerometerEvent(self.acceleration)
+        new_buttons = self.buttons & (~prev_state.buttons)
+        for button in common.Button:
+            if button in new_buttons:
+                yield ButtonDownEvent(button)
+        released_buttons = prev_state.buttons & (~self.buttons)
+        for button in common.Button:
+            if button in released_buttons:
+                yield ButtonDownEvent(button)
 
 # TODO: Break this out into a util library if it seems useful.
 def with_lock(lock):
@@ -43,11 +109,20 @@ class Player:
         self.effect_lock_ = asyncio.Lock()
         self.warn_ = None
         self.effect_ = None
+        self.previous_state_ = ControllerState(move)
+        self.flush_events_()
 
-    def get_events(self) -> typing.Iterator[ControllerState]:
+    def flush_events_(self):
+        while self.move_.poll(): pass
+
+    def get_events(self) -> typing.Iterator[ControllerEvent]:
         """Returns an iterator over events currently pending on the controller."""
         while self.move_.poll():
-            yield ControllerState(self.move_)
+            state = ControllerState(self.move_)
+            for ev in state.get_events_from_state_diff(self.previous_state_):
+                ev.player = self
+                yield ev
+            self.previous_state_ = state
         # TODO: The moves need to be occasionally prodded to keep their leds lit.
         # If we make the piparty loop async, move this logic in there as a task.
         self.move_.update_leds()
@@ -143,11 +218,10 @@ class PlayerCollection:
     def kill_player(self, player: Player):
         self.active_players.remove(player)
         return player.show_death()
-    def active_player_events(self):
+    def active_player_events(self, event_type: EventType):
         # consider randomizing this so players don't get an advantage by being first in the list.
         for player in list(self.active_players):
-            for event in player.get_events():
-                yield player, event
+            yield from (e for e in player.get_events() if e.type in event_type)
     def cancel_effects(self):
         for player in self.players:
             player.cancel_effect()


### PR DESCRIPTION
  * We add a 'PaceManager' that keeps track of tempos, and switches between them at configured intervals.
  * Instead of pushing controller state to the game loop, the Player object computes deltas, and sends 'events' like BUTTON_DOWN.

Based on 'top', the new game mode consumes about 1/4 as much CPU as the old FFA when using two controllers. I expect bigger savings with more controllers.