### PR TITLE
Set volume to 100% permanently 

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -72,6 +72,9 @@ setup() {
     #makes sound card 1(usb audio) to be default output
     #use aplay -l to check sound card number
     #sudo cp /home/pi/JoustMania/asound.conf /etc/
+    
+    #Use amixer to set sound output to 100%
+    amixer sset PCM,0 100%
 
     # Pause a second before rebooting so we can see all the output from this script.
     (sleep 1; sudo reboot) &

--- a/setup.sh
+++ b/setup.sh
@@ -75,6 +75,7 @@ setup() {
     
     #Use amixer to set sound output to 100%
     amixer sset PCM,0 100%
+    sudo alsactl store
 
     # Pause a second before rebooting so we can see all the output from this script.
     (sleep 1; sudo reboot) &


### PR DESCRIPTION
Set volume to 100% in setup script to reduce inconsistencies between installs.