### PR TITLE
Fixed eth0 in AP mode

### DIFF
--- a/apfiles/interfaces
+++ b/apfiles/interfaces
@@ -9,7 +9,8 @@ source-directory /etc/network/interfaces.d
 auto lo
 iface lo inet loopback
 
-iface eth0 inet manual
+auto eth0
+iface eth0 inet dhcp
 
 #Access point for JoustMania
 allow-hotplug wlan0


### PR DESCRIPTION
Enabled eth0 NIC and set to dhcp. Tested functionality of AP and traffic passthrough.