### PR TITLE
initialize pygame mixer before use

### DIFF
--- a/piaudio.py
+++ b/piaudio.py
@@ -189,6 +189,7 @@ class Audio:
         #buf = io.BytesIO()
         #segment.export(buf, 'wav')
         #buf.seek(0)
+        pygame.mixer.init()
         self.sample_ = pygame.mixer.Sound(file=fname)
         self.fname_ = fname
 


### PR DESCRIPTION
It seems that pygame.mixer was not always initialized. 
Fixes #305