### PR TITLE
Update disable_internal_bluetooth.sh for debian 12 and later

### DIFF
--- a/disable_internal_bluetooth.sh
+++ b/disable_internal_bluetooth.sh
@@ -1,9 +1,18 @@
+#!/bin/bash
 # this will disable on-board bluetooth
-#this will allow only class one long range btdongles to connect to psmove controllers
-sudo echo "dtoverlay=pi3-disable-bt" | sudo tee -a /boot/config.txt
-sudo systemctl disable hciuart
+# this will allow only class one long range btdongles to connect to psmove controllers
 
-#remove onboard bluetooth folders
+DIST_REL=$(cut -f2 <<< $(lsb_release -r))
+if [ "$DIST_REL" -ge 12 ]; then
+	echo "the distribution $DIST_REL is larger than 12"
+	config_loc=/boot/firmware/config.txt || exit -1
+else
+	echo "the distribution is smaller than 12"
+	config_loc=/boot/config.txt || exit -1
+fi
+
+echo "dtoverlay=disable-bt" | sudo tee -a $config_loc
 sudo rm -rf /var/lib/bluetooth/*
+sudo systemctl disable hciuart
 
 sudo reboot


### PR DESCRIPTION
the original disable_internal_bluetooth.sh was hard-coded for earlier versions of debian, before config.txt was moved to /boot/firmware.  This change makes disabling internal bluetooth (for those installs where it was not specified during setup.sh) compatible with modern versions.  The method is copied from setup.sh --disable_internal_bt