### PR TITLE
sometimes logname returns nothing and crashes this script and startup

### DIFF
--- a/update_asound.sh
+++ b/update_asound.sh
@@ -2,7 +2,7 @@
 
 # Prevent apt from prompting us about restarting services.
 export DEBIAN_FRONTEND=noninteractive
-HOMENAME=`logname`
+HOMENAME=`who | head -n1 | cut -d " " -f1`
 HOMEDIR=/home/$HOMENAME
 cd $HOMEDIR
 


### PR DESCRIPTION
don't know why logname sometimes returns nothing, but i replaced it with the method used in controller_util_test.sh, joust.sh, and webui.sh as well as "tests" which is:
`HOMENAME=$(who | head -n1 | cut -d " " -f1)`
another option would be
`HOMENAME=$(stat -c %U $0)`
which would return the username of the owner of the script itself