### PR TITLE
Fix web shutdown and reboot actions

### DIFF
--- a/system_power.py
+++ b/system_power.py
@@ -1,0 +1,20 @@
+"""Request host power actions without terminating the requesting process first."""
+
+import subprocess
+import time
+
+
+_POWER_ACTIONS = frozenset(("poweroff", "reboot"))
+
+
+def request_system_power(action, delay=2):
+    """Queue a systemd power action after allowing the web response to finish."""
+    if action not in _POWER_ACTIONS:
+        raise ValueError("Unsupported system power action: {}".format(action))
+
+    time.sleep(delay)
+    # Hand the request to systemd before shutdown stops JoustMania's process group.
+    subprocess.run(
+        ["sudo", "systemctl", "--no-block", action],
+        check=True,
+    )

--- a/test_system_power.py
+++ b/test_system_power.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest import mock
+
+import system_power
+
+
+class SystemPowerTest(unittest.TestCase):
+    @mock.patch("system_power.subprocess.run")
+    @mock.patch("system_power.time.sleep")
+    def test_requests_nonblocking_poweroff(self, sleep, run):
+        system_power.request_system_power("poweroff")
+
+        sleep.assert_called_once_with(2)
+        run.assert_called_once_with(
+            ["sudo", "systemctl", "--no-block", "poweroff"],
+            check=True,
+        )
+
+    @mock.patch("system_power.subprocess.run")
+    @mock.patch("system_power.time.sleep")
+    def test_requests_nonblocking_reboot(self, sleep, run):
+        system_power.request_system_power("reboot")
+
+        sleep.assert_called_once_with(2)
+        run.assert_called_once_with(
+            ["sudo", "systemctl", "--no-block", "reboot"],
+            check=True,
+        )
+
+    @mock.patch("system_power.subprocess.run")
+    @mock.patch("system_power.time.sleep")
+    def test_rejects_unknown_action(self, sleep, run):
+        with self.assertRaisesRegex(ValueError, "Unsupported system power action"):
+            system_power.request_system_power("suspend")
+
+        sleep.assert_not_called()
+        run.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webui.py
+++ b/webui.py
@@ -1,16 +1,15 @@
 from multiprocessing import Queue, Manager, Process
 import socket
-from time import sleep
 from flask import Flask, render_template, request, redirect, url_for, flash
-from time import sleep
 from wtforms import Form, SelectField, SelectMultipleField, BooleanField, widgets, FieldList
-from os import environ, system
+from os import environ
 from sys import platform
 import common, colors
 import json
 import yaml
 import logging
 import runtime_platform
+from system_power import request_system_power
 
 if platform == "linux" or platform == "linux2":
     import psmove_dbus
@@ -211,13 +210,9 @@ class WebUI():
 
     #@app.route('/shutdown8675309')
     def shutdown(self):
-        Process(target=self.shutdown_proc).start()
+        Process(target=request_system_power, args=('poweroff',)).start()
         #use redirect to conceal the url for tripping the shutdown
         return redirect(url_for('shutdown_lastscreen'))
-
-    def shutdown_proc(self):
-        sleep(2)
-        system("sudo kill -3 $(ps aux | grep '[p]iparty' | awk '{print $2}') ; sudo supervisorctl stop joustmania ; sudo shutdown -H now ")
 
     #@app.route('/shutdown_lastscreen')
     def shutdown_lastscreen(self):
@@ -225,12 +220,8 @@ class WebUI():
 
     #@app.route('/reboot8675309')
     def reboot(self):
-        Process(target=self.reboot_proc).start()
+        Process(target=request_system_power, args=('reboot',)).start()
         return redirect(url_for('index'))
-
-    def reboot_proc(self):
-        sleep(2)
-        system(" sudo kill -3 $(ps aux | grep '[p]iparty' | awk '{print $2}') ; sudo supervisorctl stop joustmania ; sudo reboot now ")
         
 
     #@app.route('/settings')


### PR DESCRIPTION
## Summary
- queue reboot and poweroff directly through systemd
- remove the shell pipeline that killed JoustMania before the power command ran
- add focused tests for both power actions

## Testing
- python -m unittest discover -p "test_*.py" (21 tests)
- Tested on raspberry pi, both power and reboot work as expected.

Fixes #372