### PR TITLE
Remove unloaded PS Move registrations on Linux

### DIFF
--- a/clear_devices.py
+++ b/clear_devices.py
@@ -1,12 +1,24 @@
 """Remove saved PS Move Bluetooth registrations from the local host."""
 
 import argparse
+import shutil
 import sys
+from pathlib import Path
 
 
 def clear_linux_devices(dry_run=False):
     import jm_dbus
     import psmove_dbus
+
+    # BlueZ does not always load registrations saved under
+    # /var/lib/bluetooth (for example, when their adapter is unavailable).
+    # Keep those registrations in the reset scope even though they cannot be
+    # removed through Adapter1.RemoveDevice.
+    saved_only = [
+        controller
+        for controller in psmove_dbus.get_registered_controllers()
+        if not controller['loaded']
+    ]
 
     hcis = jm_dbus.get_hci_dict().keys()
     removed = 0
@@ -26,6 +38,30 @@ def clear_linux_devices(dry_run=False):
             if not dry_run:
                 jm_dbus.remove_device(hci, dev)
             removed += 1
+
+    bluetooth_dir = Path('/var/lib/bluetooth')
+    for controller in saved_only:
+        registration_dir = (
+            bluetooth_dir
+            / controller['adapter_address']
+            / controller['address']
+        )
+        action = "Would remove" if dry_run else "Removing"
+        print(
+            "{} saved PS Move {} from adapter {}".format(
+                action,
+                controller['address'],
+                controller['adapter_address'],
+            )
+        )
+        if not dry_run:
+            try:
+                shutil.rmtree(str(registration_dir))
+            except FileNotFoundError:
+                # The registration may have disappeared while BlueZ was
+                # restarting. Treat that as an already-completed removal.
+                pass
+        removed += 1
 
     return removed
 


### PR DESCRIPTION
## Summary

- include saved PS Move registrations that are not loaded into BlueZ in the Linux reset
- remove only registrations already validated as ZCM1 or ZCM2 by the shared controller discovery code
- tolerate registrations disappearing during a BlueZ restart

## Problem

`reset_psmove_connections.sh` only enumerated live BlueZ D-Bus devices. The controller status page also reads valid registrations from `/var/lib/bluetooth`, so unloaded controllers appeared as registered after reset while the tool reported `Removed 0`.

## Verification

- dry-run identified exactly 7 stale PS Move registrations across 3 adapters
- corrected reset removed all 7 registrations
- `debug_psmove_connections.py` then reported no registered PS Move controllers
- unrelated Bluetooth registration remained intact
- Python syntax compilation and `git diff --check` passed
- `test_system_power.py` passed; `test_pair.py` could not import because `psmoveapi` is unavailable in this checkout