### PR TITLE
Add live Bluetooth controller diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Optional and recommended:
 Note on Hardware: The internal bluetooth is shorter range and has a slightly higher latency
 The class 1 adapters allow bluetooth connections up to 300+ feet and allow for the gameplay to be smooth, each adapter can connect to 6 to 7 controllers. I've tested this build with four adapters and 18 controllers successfully.
 
+On Linux, JoustMania automatically requests the Bluetooth Peripheral role for
+connected PS Move controllers. In testing, some ZCM1 controllers on Realtek
+adapters ran at only about 65 updates per second in Central role, but reached
+about 87–89 updates per second in Peripheral role. ZCM2 controllers normally
+report much higher rates. The live System Debug page shows each controller's
+role and update rate, with rates above 80 updates per second shown in green.
+
 Optional:
 
 * USB hub for charging controllers: [SABRENT 13 Port](https://www.amazon.com/gp/product/B00HL7Z46K) [SIIG 10 Port](http://a.co/7T3HDmJ)

--- a/bluetooth_diagnostics.py
+++ b/bluetooth_diagnostics.py
@@ -1,0 +1,131 @@
+"""Read-only Bluetooth adapter diagnostics for the debug web page."""
+
+import re
+import subprocess
+from pathlib import Path
+
+
+_COUNTERS = re.compile(
+    r"RX bytes:(?P<rx_bytes>\d+) acl:(?P<rx_acl>\d+).*?errors:(?P<rx_errors>\d+)\s+"
+    r"TX bytes:(?P<tx_bytes>\d+) acl:(?P<tx_acl>\d+).*?errors:(?P<tx_errors>\d+)",
+    re.DOTALL,
+)
+_POWER_CACHE = {}
+
+
+def _read(path):
+    try:
+        return path.read_text(errors="replace").strip()
+    except OSError:
+        return ""
+
+
+def _usb_details(hci):
+    """Find the USB device above an HCI interface without invoking udev."""
+    try:
+        current = (Path("/sys/class/bluetooth") / hci / "device").resolve()
+    except OSError:
+        return {}
+    for parent in (current, *current.parents):
+        vendor = _read(parent / "idVendor")
+        product_id = _read(parent / "idProduct")
+        if vendor and product_id:
+            return {
+                "usb_id": "{}:{}".format(vendor, product_id),
+                "vendor": _read(parent / "manufacturer") or "Unknown",
+                "product": _read(parent / "product") or "Unknown USB adapter",
+                "usb_speed": _read(parent / "speed"),
+                "usb_path": parent.name,
+            }
+    return {}
+
+
+def parse_hciconfig(output):
+    """Parse the stable, human-readable fields emitted by hciconfig -a."""
+    adapters = []
+    for block in re.split(r"(?m)(?=^hci\d+:)", output):
+        name_match = re.match(r"(hci\d+):", block)
+        if not name_match:
+            continue
+        address = re.search(r"BD Address:\s*([0-9A-F:]+)", block, re.I)
+        manufacturer = re.search(r"Manufacturer:\s*(.+)", block)
+        hci_version = re.search(r"HCI Version:\s*([^\n]+)", block)
+        mtu = re.search(r"ACL MTU:\s*([^\s]+)", block)
+        counters = _COUNTERS.search(block)
+        adapter = {
+            "name": name_match.group(1),
+            "address": address.group(1).upper() if address else "Unknown",
+            "powered": "UP RUNNING" in block,
+            "manufacturer": manufacturer.group(1).strip() if manufacturer else "Unknown",
+            "hci_version": hci_version.group(1).strip() if hci_version else "Unknown",
+            "acl_mtu": mtu.group(1) if mtu else "Unknown",
+        }
+        if counters:
+            adapter.update({key: int(value) for key, value in counters.groupdict().items()})
+        else:
+            adapter.update({key: 0 for key in (
+                "rx_bytes", "rx_acl", "rx_errors", "tx_bytes", "tx_acl", "tx_errors"
+            )})
+        adapter.update(_usb_details(adapter["name"]))
+        adapter["health"] = _health(adapter)
+        adapters.append(adapter)
+    return adapters
+
+
+def _health(adapter):
+    if not adapter["powered"]:
+        return "Adapter is down"
+    if adapter["rx_errors"] or adapter["tx_errors"]:
+        return "HCI errors detected"
+    return "No reported errors"
+
+
+def _connection_count(hci):
+    """Count live HCI links exposed by the kernel (for example hci0:12)."""
+    bluetooth_class = Path("/sys/class/bluetooth")
+    try:
+        return sum(1 for _path in bluetooth_class.glob("{}:*".format(hci)))
+    except OSError:
+        return 0
+
+
+def _inquiry_tx_power(hci, address):
+    """Read configured inquiry TX power in dBm, caching static adapter data.
+
+    Bluetooth HCI does not expose a reliable radio power-class identity. This
+    value is useful measured configuration, but must not be presented as proof
+    of Class 1, 2, or 3 hardware.
+    """
+    if address in _POWER_CACHE:
+        return _POWER_CACHE[address]
+    try:
+        result = subprocess.run(
+            ["hciconfig", hci, "inqtpl"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+        match = re.search(r"Inquiry transmit power level:\s*(-?\d+)", result.stdout)
+        value = int(match.group(1)) if match else None
+    except (OSError, subprocess.TimeoutExpired):
+        value = None
+    _POWER_CACHE[address] = value
+    return value
+
+
+def get_adapters():
+    """Return adapter identity and cumulative traffic/error counters."""
+    try:
+        result = subprocess.run(
+            ["hciconfig", "-a"], capture_output=True, text=True, timeout=3, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    adapters = parse_hciconfig(result.stdout)
+    for adapter in adapters:
+        adapter["connections"] = _connection_count(adapter["name"])
+        adapter["inquiry_tx_power_dbm"] = _inquiry_tx_power(
+            adapter["name"], adapter["address"]
+        )
+    return adapters

--- a/bluetooth_roles.py
+++ b/bluetooth_roles.py
@@ -1,0 +1,126 @@
+"""Inspect and optimize Bluetooth Classic roles for PS Move connections."""
+
+import re
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+
+_CONNECTION = re.compile(
+    r"ACL\s+([0-9A-F:]{17})\s+handle\s+(\d+).*?\blm\s+(CENTRAL|PERIPHERAL)\b",
+    re.I,
+)
+
+
+def get_connection_roles(adapter_names):
+    """Return controller addresses mapped to adapter, handle, and local role."""
+    connections = {}
+    for adapter in adapter_names:
+        try:
+            result = subprocess.run(
+                ["hcitool", "-i", adapter, "con"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        for address, handle, role in _CONNECTION.findall(result.stdout):
+            connections[address.upper()] = {
+                "adapter": adapter,
+                "handle": int(handle),
+                "role": role.title(),
+            }
+    return connections
+
+
+def ensure_peripheral(address, adapter_names, attempts=5, retry_delay=0.2):
+    """Best-effort switch of one live connection to the local Peripheral role."""
+    address = address.upper()
+    last_connection = None
+    for attempt in range(attempts):
+        connection = get_connection_roles(adapter_names).get(address)
+        if connection is not None:
+            last_connection = connection
+            if connection["role"] == "Peripheral":
+                return {"success": True, **connection}
+            try:
+                subprocess.run(
+                    [
+                        "hcitool", "-i", connection["adapter"], "sr",
+                        address, "peripheral",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=2,
+                    check=False,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+            updated = get_connection_roles(adapter_names).get(address)
+            if updated is not None:
+                last_connection = updated
+                if updated["role"] == "Peripheral":
+                    return {"success": True, **updated}
+        if attempt + 1 < attempts:
+            time.sleep(retry_delay)
+    return {"success": False, **(last_connection or {})}
+
+
+def _adapter_names():
+    return sorted(
+        path.name for path in Path('/sys/class/bluetooth').glob('hci[0-9]*')
+        if ':' not in path.name
+    )
+
+
+def enforce_active_peripheral_roles(controller_manager):
+    """Request Peripheral for active PS Move links that are currently Central."""
+    active_addresses = {
+        str(address).upper() for address in controller_manager.connected_serials()
+    }
+    adapter_names = _adapter_names()
+    roles = get_connection_roles(adapter_names)
+    attempted = []
+    for address in active_addresses:
+        connection = roles.get(address)
+        if connection is None or connection['role'] != 'Central':
+            continue
+        attempted.append(address)
+        try:
+            subprocess.run(
+                [
+                    'hcitool', '-i', connection['adapter'], 'sr',
+                    address, 'peripheral',
+                ],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    return attempted
+
+
+def start_peripheral_role_monitor(controller_manager, interval=1.0):
+    """Continuously repair late or renegotiated PS Move connection roles."""
+    def monitor():
+        while True:
+            try:
+                enforce_active_peripheral_roles(controller_manager)
+            except Exception:
+                # Diagnostics report the live role. A monitoring failure must
+                # never take down the game or controller input path.
+                pass
+            time.sleep(interval)
+
+    thread = threading.Thread(
+        target=monitor,
+        name='PSMove-role-monitor',
+        daemon=True,
+    )
+    thread.start()
+    return thread

--- a/pair.py
+++ b/pair.py
@@ -43,9 +43,13 @@ class Pair():
         """
         self.hci_dict = jm_dbus.get_hci_dict()
 
-        for addr in self.hci_dict.values():
-            if addr not in self.bt_devices.keys():
-                self.bt_devices[addr] = []
+        # Remove unplugged adapters as well as adding new ones. Otherwise a
+        # hot-swap can leave pairing aimed at an address that no longer exists,
+        # causing PSMoveAPI to fall back to its first enumerated adapter.
+        self.bt_devices = {
+            addr: self.bt_devices.get(addr, [])
+            for addr in self.hci_dict.values()
+        }
 
         self.pre_existing_devices()
 
@@ -64,9 +68,20 @@ class Pair():
     def pair_move(self, move_controller):
         if move_controller and move_controller.serial:
             if move_controller.usb and not move_controller.bluetooth:
-                self.pre_existing_devices()
+                # Adapter dongles can be hot-swapped while JoustMania runs.
+                # Refresh names and addresses immediately before choosing.
+                self.update_adapters()
                 # A saved BlueZ registration does not prove that the controller
                 # still stores this Pi as its Bluetooth host. Pairing over USB
                 # rewrites that address after use with another computer.
-                return controller_manager.pair_controller(self.get_lowest_bt_device())
+                host_address = self.get_lowest_bt_device()
+                paired = controller_manager.pair_controller(host_address)
+                if paired:
+                    # BlueZ may need a few seconds to publish the registration.
+                    # Reserve it immediately so another controller paired in
+                    # that window is assigned to the next least-loaded adapter.
+                    self.bt_devices.setdefault(host_address, [])
+                    if move_controller.serial not in self.bt_devices[host_address]:
+                        self.bt_devices[host_address].append(move_controller.serial)
+                return paired
         return False

--- a/piparty.py
+++ b/piparty.py
@@ -53,6 +53,7 @@ import logging.config
 import setproctitle
 
 if platform == "linux" or platform == "linux2":
+    import bluetooth_roles
     import dbus
     import jm_dbus
     import pair
@@ -349,9 +350,6 @@ class Menu():
         self.command_queue = Queue()
         self.joust_manager = Manager()
         self.ns = self.joust_manager.Namespace()
-        # Start web server
-        self.web_proc = Process(target=webui.start_web, args=(self.command_queue,self.ns))
-        self.web_proc.start()
         self.ns.status = dict()
         self.ns.settings = dict()
         self.ns.battery_status = dict()
@@ -374,6 +372,18 @@ class Menu():
         # All of the moves connected via BT or USB, moves connected via both will appear twice
         self.controller_manager = controller_manager.get_manager()
         self.moves = self.controller_manager.connected_controllers()
+        if platform == "linux" or platform == "linux2":
+            self.bluetooth_role_monitor = bluetooth_roles.start_peripheral_role_monitor(
+                self.controller_manager
+            )
+
+        # Give the WebUI direct access to the shared controller sequences so
+        # live update rates continue advancing while a game owns the menu loop.
+        self.web_proc = Process(
+            target=webui.start_web,
+            args=(self.command_queue, self.ns, self.controller_manager),
+        )
+        self.web_proc.start()
 
         self.move_count = self.get_move_count() # Number of connected moves used in webui
 
@@ -493,6 +503,22 @@ class Menu():
         #If move is not already being tracked
         if move_serial not in self.tracked_moves:
             logger.debug("Pairing BT move: {}".format(move_serial))
+            if platform == "linux" or platform == "linux2":
+                role_result = bluetooth_roles.ensure_peripheral(
+                    move_serial,
+                    list(jm_dbus.get_hci_dict().keys()),
+                )
+                if role_result.get("success"):
+                    logger.info(
+                        "Bluetooth role for %s is Peripheral on %s",
+                        move_serial,
+                        role_result.get("adapter", "unknown adapter"),
+                    )
+                else:
+                    logger.warning(
+                        "Could not switch Bluetooth role for %s to Peripheral",
+                        move_serial,
+                    )
             color = Array('i', [0] * 3)
             # TODO: this probably should be tracked above
             # Individual move run-time parameters, initialize them all to 0
@@ -1006,6 +1032,15 @@ class Menu():
 
         self.ns.battery_status = battery_status
         self.ns.out_moves = self.out_moves
+        # state_sequence advances twice for every complete PSMoveAPI update.
+        # Publish cumulative per-controller counts so the WebUI can calculate
+        # rates without consuming controller input or opening another API.
+        self.ns.controller_update_counts = {
+            controller.serial: int(
+                self.controller_manager.state_sequence[controller.index] // 2
+            )
+            for controller in self.moves
+        }
 
     def stop_tracking_moves(self):
         for proc in self.tracked_moves.values():

--- a/reset_psmove_connections.sh
+++ b/reset_psmove_connections.sh
@@ -8,12 +8,24 @@ fi
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 PYTHON="$SCRIPT_DIR/venv/bin/python3"
+JOUSTMANIA_STOPPED=0
+
+restart_joustmania() {
+    if [ "$JOUSTMANIA_STOPPED" -eq 1 ]; then
+        echo "Starting JoustMania..."
+        "$SCRIPT_DIR/start_joustmania.sh" || true
+    fi
+}
+
+# Once this workflow stops the service, make a best effort to start it even
+# when controller cleanup fails.
+trap restart_joustmania EXIT
 
 if [ ! -x "$PYTHON" ]; then
     PYTHON=python3
 fi
 
+JOUSTMANIA_STOPPED=1
 "$SCRIPT_DIR/stop_joustmania.sh"
 cd "$SCRIPT_DIR"
 "$PYTHON" clear_devices.py
-"$SCRIPT_DIR/start_joustmania.sh"

--- a/restart_joustmania.sh
+++ b/restart_joustmania.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "${UID}" -ne 0 ]; then
+    echo "Not root. Using sudo."
+    exec sudo "$0" "$@"
+fi
+
+echo "Restarting JoustMania..."
+supervisorctl restart joustmania
+supervisorctl status joustmania

--- a/static/jouststyle.css
+++ b/static/jouststyle.css
@@ -22,6 +22,14 @@ button:hover {
     background-color: #0056b3;
 }
 
+.danger-button {
+    background-color: #c82333;
+}
+
+.danger-button:hover {
+    background-color: #9f1c28;
+}
+
 a button {
     background-color: #28a745;
 }

--- a/templates/bluetooth_reset.html
+++ b/templates/bluetooth_reset.html
@@ -1,0 +1,10 @@
+{% extends "basic.html" %}
+
+{% block body %}
+<div class="info_box">
+    <h2>Bluetooth Reset Started</h2>
+    <p>JoustMania is stopping, clearing saved PS Move connections, and restarting. This page may disconnect briefly.</p>
+    <p>Wait about 10 seconds, then open the debug dashboard again.</p>
+    <a href="/debug"><button type="button">Return to System Debug</button></a>
+</div>
+{% endblock %}

--- a/templates/controller_debug.html
+++ b/templates/controller_debug.html
@@ -11,21 +11,52 @@
 .batt1, .batt0 { background-color: red; }
 .batt238 { background-color: gray; }
 .batt239 { background-color: lightgray; }
+.diagnostic-note { max-width: 70em; }
+.nowrap { white-space: nowrap; }
+.adapter-section { margin-top: 24px; padding-top: 16px; border-top: 3px solid #ddd; overflow-x: auto; }
+.adapter-section h3 { margin-bottom: 8px; }
+.controller-table { margin: 12px 0 20px; }
+.rate-slow { background-color: #ff8080; }
+.rate-warning { background-color: #ffe680; }
+.rate-good { background-color: #80ff80; }
 </style>
 {% endblock %}
 
 {% block body %}
 <div class="info_box">
-    <h2>Controller Status</h2>
-
-    <table>
+    <h2>Bluetooth Adapters</h2>
+    <p class="diagnostic-note">Live rates are HCI packets handled by each adapter. With controllers connected,
+    a much lower RX ACL rate identifies the slow path directly. With no controllers, identity and hardware error
+    checks still work, but an idle adapter cannot prove radio throughput; “No reported errors” is not a speed test.</p>
+    <div id="bluetooth-adapter-body">
+    {% for adapter in adapters %}
+    <section class="adapter-section" data-adapter-section="{{ adapter.name }}">
+        <h3><span class="adapter-name">{{ adapter.name }}</span> — <span class="adapter-address">{{ adapter.address }}</span></h3>
+        <table>
+        <thead><tr>
+            <th>Chipset</th><th>USB device</th><th>USB link</th>
+            <th>Bluetooth</th><th>Inquiry TX power</th><th>ACL MTU</th><th>Links</th><th>RX ACL/s/link</th><th>TX ACL/s/link</th><th>Errors</th><th>Assessment</th>
+        </tr></thead>
+        <tbody>
+            <tr data-adapter="{{ adapter.name }}" data-rx="{{ adapter.rx_acl }}" data-tx="{{ adapter.tx_acl }}">
+                <td class="adapter-manufacturer">{{ adapter.manufacturer }}</td><td class="adapter-usb-device">{{ adapter.product }} ({{ adapter.usb_id or 'Unknown' }})</td>
+                <td class="adapter-usb-speed">{{ adapter.usb_speed or 'Unknown' }} Mb/s at {{ adapter.usb_path or 'unknown path' }}</td><td class="adapter-hci-version">{{ adapter.hci_version }}</td>
+                <td class="adapter-tx-power">{% if adapter.inquiry_tx_power_dbm is not none %}{{ adapter.inquiry_tx_power_dbm }} dBm{% else %}Unavailable{% endif %}</td>
+                <td class="adapter-acl-mtu">{{ adapter.acl_mtu }}</td><td class="connections">{{ adapter.connections }}</td>
+                <td class="rx-rate">Measuring…</td><td class="tx-rate">Measuring…</td>
+                <td class="errors">{{ adapter.rx_errors + adapter.tx_errors }}</td><td class="health">{{ adapter.health }}</td>
+            </tr>
+        </tbody>
+        </table>
+        <h4>Controllers on {{ adapter.name }}</h4>
+        <table class="controller-table">
         <thead>
             <tr>
                 <th>Status</th>
+                <th>Updates/s</th>
+                <th>Role</th>
                 <th>Battery</th>
                 <th>Active</th>
-                <th>Adapter</th>
-                <th>Adapter Address</th>
                 <th>Controller</th>
                 <th>Model</th>
                 <th>Registered</th>
@@ -36,14 +67,14 @@
                 <th>Services</th>
             </tr>
         </thead>
-        <tbody>
-            {% for controller in controllers %}
-            <tr>
+        <tbody class="controller-status-body" data-for-adapter="{{ adapter.name }}">
+            {% for controller in adapter.controllers %}
+            <tr data-controller="{{ controller.address }}">
                 <td class="{% if controller.connected %}connected{% else %}disconnected{% endif %}">{{ controller.status }}</td>
+                <td class="controller-rate">Measuring…</td>
+                <td>{{ controller.role }}</td>
                 <td{% if controller.battery_code is not none %} class="batt{{ controller.battery_code }}"{% endif %}>{{ controller.battery }}</td>
                 <td>{% if controller.active is none %}Unknown{% elif controller.active %}Yes{% else %}No{% endif %}</td>
-                <td>{{ controller.adapter }}</td>
-                <td>{{ controller.adapter_address }}</td>
                 <td>{{ controller.address }}</td>
                 <td>{{ controller.model }}</td>
                 <td>Yes</td>
@@ -55,13 +86,141 @@
             </tr>
             {% else %}
             <tr>
-                <td colspan="13">No PS Move controllers are registered.</td>
+                <td colspan="13">No controllers are assigned to this adapter.</td>
             </tr>
             {% endfor %}
         </tbody>
-    </table>
+        </table>
+    </section>
+    {% else %}
+        <p>No Bluetooth adapters were found.</p>
+    {% endfor %}
+    </div>
 
-    <p><a href="/debug/controllers"><button type="button">Refresh</button></a>
-    <a href="/"><button type="button">Go Back</button></a></p>
+    <div id="unassigned-controller-section" class="adapter-section" style="display: none;">
+        <h3>Unassigned or unavailable adapter</h3>
+        <table class="controller-table"><tbody class="controller-status-body" data-for-adapter="unknown"></tbody></table>
+    </div>
+    <p><a href="/"><button type="button">Go Back</button></a></p>
+    <form action="/debug/restart-joustmania" method="POST"
+          onsubmit="return confirm('Restart JoustMania? This stops the current game but does not reboot the computer or clear Bluetooth connections.');">
+        <button type="submit">Restart JoustMania</button>
+    </form>
+    <p class="diagnostic-note">Restarts only the JoustMania application. It does not reboot the computer or remove controller pairings.</p>
+    <form action="/debug/reset-bluetooth" method="POST"
+          onsubmit="return confirm('Reset Bluetooth controllers? This stops the current game, removes saved PS Move connections, and restarts JoustMania.');">
+        <button type="submit" class="danger-button">Reset Bluetooth Controllers</button>
+    </form>
+    <p class="diagnostic-note">This stops the current game, clears saved PS Move registrations, and restarts JoustMania. Controllers may need to reconnect or be paired again.</p>
 </div>
+<script>
+(function () {
+    let lastTime = Date.now();
+    const controllerLast = {};
+    function cell(row, value, className) {
+        const item = document.createElement('td');
+        item.textContent = value;
+        if (className) item.className = className;
+        row.appendChild(item);
+    }
+    function renderControllers(controllers, seconds) {
+        const bodies = Array.from(document.querySelectorAll('.controller-status-body'));
+        bodies.forEach(function (body) { body.textContent = ''; });
+        controllers.forEach(function (controller) {
+            let body = document.querySelector('.controller-status-body[data-for-adapter="' + controller.adapter + '"]');
+            if (!body) body = document.querySelector('.controller-status-body[data-for-adapter="unknown"]');
+            const row = document.createElement('tr');
+            row.dataset.controller = controller.address;
+            cell(row, controller.status, controller.connected ? 'connected' : 'disconnected');
+            let rate = 'Unavailable';
+            if (!controller.connected) {
+                rate = '—';
+                if (controller.update_count !== null) controllerLast[controller.address] = controller.update_count;
+            } else if (controller.update_count !== null) {
+                if (controllerLast[controller.address] !== undefined) {
+                    rate = Math.max(0, (controller.update_count - controllerLast[controller.address]) / seconds).toFixed(1);
+                } else {
+                    rate = 'Measuring…';
+                }
+                controllerLast[controller.address] = controller.update_count;
+            }
+            let rateClass = 'controller-rate';
+            if (typeof rate === 'string' && /^\d/.test(rate)) {
+                const numericRate = Number(rate);
+                if (numericRate < 70) rateClass += ' rate-slow';
+                else if (numericRate <= 80) rateClass += ' rate-warning';
+                else rateClass += ' rate-good';
+            }
+            cell(row, rate, rateClass);
+            cell(row, controller.role);
+            cell(row, controller.battery, controller.battery_code === null ? '' : 'batt' + controller.battery_code);
+            cell(row, controller.active === null ? 'Unknown' : (controller.active ? 'Yes' : 'No'));
+            cell(row, controller.address);
+            cell(row, controller.model); cell(row, 'Yes'); cell(row, controller.loaded ? 'Yes' : 'No');
+            cell(row, controller.paired ? 'Yes' : 'No'); cell(row, controller.connected ? 'Yes' : 'No');
+            cell(row, controller.trusted ? 'Yes' : 'No'); cell(row, controller.services_resolved ? 'Ready' : 'Not ready');
+            body.appendChild(row);
+        });
+        bodies.forEach(function (body) {
+            if (body.children.length) return;
+            const row = document.createElement('tr');
+            const item = document.createElement('td');
+            item.colSpan = 13;
+            item.textContent = body.dataset.forAdapter === 'unknown'
+                ? 'No unassigned controllers.'
+                : 'No controllers are assigned to this adapter.';
+            row.appendChild(item); body.appendChild(row);
+        });
+        const unassignedBody = document.querySelector('.controller-status-body[data-for-adapter="unknown"]');
+        document.getElementById('unassigned-controller-section').style.display =
+            controllers.some(function (controller) {
+                return !document.querySelector('[data-adapter-section="' + controller.adapter + '"]');
+            }) ? '' : 'none';
+    }
+    window.setInterval(function () {
+        fetch('/debug/data', {cache: 'no-store'}).then(function (response) { return response.json(); }).then(function (data) {
+            const now = Date.now();
+            const seconds = Math.max((now - lastTime) / 1000, 0.001);
+            const adapterRows = Array.from(document.querySelectorAll('#bluetooth-adapter-body [data-adapter]'));
+            const displayedAdapters = adapterRows.map(function (row) { return row.dataset.adapter; }).sort();
+            const currentAdapters = data.adapters.map(function (adapter) { return adapter.name; }).sort();
+            if (displayedAdapters.join(',') !== currentAdapters.join(',')) {
+                // Adapter topology changed after this page was rendered. A
+                // reload creates/removes identity rows; ordinary live samples
+                // continue updating in place without page refreshes.
+                window.location.reload();
+                return;
+            }
+            data.adapters.forEach(function (adapter) {
+                const row = document.querySelector('[data-adapter="' + adapter.name + '"]');
+                if (!row) return;
+                const section = row.closest('[data-adapter-section]');
+                section.querySelector('.adapter-address').textContent = adapter.address;
+                row.querySelector('.adapter-manufacturer').textContent = adapter.manufacturer;
+                row.querySelector('.adapter-usb-device').textContent = adapter.product + ' (' + (adapter.usb_id || 'Unknown') + ')';
+                row.querySelector('.adapter-usb-speed').textContent = (adapter.usb_speed || 'Unknown') + ' Mb/s at ' + (adapter.usb_path || 'unknown path');
+                row.querySelector('.adapter-hci-version').textContent = adapter.hci_version;
+                row.querySelector('.adapter-tx-power').textContent = adapter.inquiry_tx_power_dbm === null ? 'Unavailable' : adapter.inquiry_tx_power_dbm + ' dBm';
+                row.querySelector('.adapter-acl-mtu').textContent = adapter.acl_mtu;
+                const oldRx = Number(row.dataset.rx), oldTx = Number(row.dataset.tx);
+                const links = Math.max(adapter.connections, 1);
+                const rxRate = Math.max(0, (adapter.rx_acl - oldRx) / seconds / links);
+                const txRate = Math.max(0, (adapter.tx_acl - oldTx) / seconds / links);
+                row.querySelector('.rx-rate').textContent = adapter.connections ? rxRate.toFixed(1) : '—';
+                row.querySelector('.tx-rate').textContent = adapter.connections ? txRate.toFixed(1) : '—';
+                row.querySelector('.connections').textContent = adapter.connections;
+                row.querySelector('.errors').textContent = adapter.rx_errors + adapter.tx_errors;
+                let health = adapter.connections ? adapter.health : 'Idle — no controller links';
+                if (adapter.connections && rxRate < 80) health = 'SLOW controller traffic';
+                else if (adapter.connections && rxRate >= 85) health = 'Healthy controller traffic';
+                else if (adapter.connections) health = 'Borderline controller traffic';
+                row.querySelector('.health').textContent = health;
+                row.dataset.rx = adapter.rx_acl; row.dataset.tx = adapter.tx_acl;
+            });
+            renderControllers(data.controllers, seconds);
+            lastTime = now;
+        }).catch(function () {});
+    }, 1000);
+}());
+</script>
 {% endblock %}

--- a/templates/joustmania.html
+++ b/templates/joustmania.html
@@ -269,7 +269,7 @@ $(document).ready(function() {
     </div>
     <br />
     <button id="startgame">Start Game</button>
-    <a href="/debug/controllers"><button>Controller Status</button></a>
+    <a href="/debug"><button>System Debug</button></a>
     <a href="/settings"><button>Admin Settings</button></a>
 </div>
 

--- a/templates/joustmania_restart.html
+++ b/templates/joustmania_restart.html
@@ -1,0 +1,10 @@
+{% extends "basic.html" %}
+
+{% block body %}
+<div class="info_box">
+    <h2>JoustMania Restart Started</h2>
+    <p>The application is restarting. The computer is not rebooting, and saved Bluetooth connections are not being removed.</p>
+    <p>Wait a few seconds, then return to the debug dashboard.</p>
+    <a href="/debug"><button type="button">Return to System Debug</button></a>
+</div>
+{% endblock %}

--- a/test_bluetooth_diagnostics.py
+++ b/test_bluetooth_diagnostics.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest import mock
+
+import bluetooth_diagnostics
+
+
+SAMPLE = """hci1: Type: Primary  Bus: USB
+    BD Address: 8C:68:8B:C3:DD:47  ACL MTU: 1021:6  SCO MTU: 255:12
+    UP RUNNING
+    RX bytes:745187 acl:12731 sco:0 events:576 errors:2
+    TX bytes:48434 acl:75 sco:0 commands:495 errors:0
+    HCI Version: 5.1 (0xa)  Revision: 0xdfc6
+    Manufacturer: Realtek Semiconductor Corporation (93)
+"""
+
+
+class BluetoothDiagnosticsTest(unittest.TestCase):
+    @mock.patch.object(bluetooth_diagnostics, "_usb_details", return_value={})
+    def test_parse_adapter_identity_and_counters(self, _usb_details):
+        adapter = bluetooth_diagnostics.parse_hciconfig(SAMPLE)[0]
+        self.assertEqual(adapter["name"], "hci1")
+        self.assertEqual(adapter["address"], "8C:68:8B:C3:DD:47")
+        self.assertEqual(adapter["rx_acl"], 12731)
+        self.assertEqual(adapter["tx_acl"], 75)
+        self.assertEqual(adapter["health"], "HCI errors detected")
+
+    @mock.patch.object(bluetooth_diagnostics.Path, "glob")
+    def test_connection_count_uses_kernel_hci_links(self, glob):
+        glob.return_value = iter(["hci1:1", "hci1:2"])
+        self.assertEqual(bluetooth_diagnostics._connection_count("hci1"), 2)
+
+    @mock.patch.object(bluetooth_diagnostics.subprocess, "run")
+    def test_inquiry_power_is_parsed_as_dbm_not_power_class(self, run):
+        run.return_value.stdout = "Inquiry transmit power level: 4\n"
+        bluetooth_diagnostics._POWER_CACHE.clear()
+        self.assertEqual(
+            bluetooth_diagnostics._inquiry_tx_power("hci0", "00:11:22:33:44:55"),
+            4,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_bluetooth_roles.py
+++ b/test_bluetooth_roles.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest import mock
+
+import bluetooth_roles
+
+
+class BluetoothRolesTest(unittest.TestCase):
+    @mock.patch.object(bluetooth_roles.subprocess, "run")
+    def test_connection_roles_are_scoped_to_adapter(self, run):
+        run.return_value.stdout = (
+            "Connections:\n"
+            "\t> ACL 00:06:F7:8F:FA:3C handle 2 state 1 lm CENTRAL \n"
+        )
+        roles = bluetooth_roles.get_connection_roles(["hci1"])
+        self.assertEqual(roles["00:06:F7:8F:FA:3C"], {
+            "adapter": "hci1", "handle": 2, "role": "Central",
+        })
+
+    @mock.patch.object(bluetooth_roles, "get_connection_roles")
+    @mock.patch.object(bluetooth_roles.subprocess, "run")
+    def test_central_connection_is_switched_and_verified(self, run, roles):
+        roles.side_effect = [
+            {"AA:BB:CC:DD:EE:FF": {"adapter": "hci1", "handle": 3, "role": "Central"}},
+            {"AA:BB:CC:DD:EE:FF": {"adapter": "hci1", "handle": 3, "role": "Peripheral"}},
+        ]
+        result = bluetooth_roles.ensure_peripheral(
+            "aa:bb:cc:dd:ee:ff", ["hci0", "hci1"], retry_delay=0
+        )
+        self.assertTrue(result["success"])
+        run.assert_called_once_with(
+            ["hcitool", "-i", "hci1", "sr", "AA:BB:CC:DD:EE:FF", "peripheral"],
+            capture_output=True, text=True, timeout=2, check=False,
+        )
+
+    @mock.patch.object(bluetooth_roles, "get_connection_roles")
+    @mock.patch.object(bluetooth_roles.subprocess, "run")
+    def test_peripheral_connection_is_left_alone(self, run, roles):
+        roles.return_value = {
+            "AA:BB:CC:DD:EE:FF": {
+                "adapter": "hci0", "handle": 1, "role": "Peripheral",
+            }
+        }
+        result = bluetooth_roles.ensure_peripheral(
+            "AA:BB:CC:DD:EE:FF", ["hci0"]
+        )
+        self.assertTrue(result["success"])
+        run.assert_not_called()
+
+    @mock.patch.object(bluetooth_roles, "_adapter_names", return_value=["hci0"])
+    @mock.patch.object(bluetooth_roles, "get_connection_roles")
+    @mock.patch.object(bluetooth_roles.subprocess, "run")
+    def test_monitor_repairs_only_active_central_links(self, run, roles, _names):
+        manager = mock.Mock()
+        manager.connected_serials.return_value = ["AA:BB:CC:DD:EE:FF"]
+        roles.return_value = {
+            "AA:BB:CC:DD:EE:FF": {
+                "adapter": "hci0", "handle": 1, "role": "Central",
+            },
+            "11:22:33:44:55:66": {
+                "adapter": "hci0", "handle": 2, "role": "Central",
+            },
+        }
+        attempted = bluetooth_roles.enforce_active_peripheral_roles(manager)
+        self.assertEqual(attempted, ["AA:BB:CC:DD:EE:FF"])
+        run.assert_called_once_with(
+            ["hcitool", "-i", "hci0", "sr", "AA:BB:CC:DD:EE:FF", "peripheral"],
+            capture_output=True, text=True, timeout=2, check=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_pair.py
+++ b/test_pair.py
@@ -8,7 +8,8 @@ import pair
 class PairTest(unittest.TestCase):
     def test_usb_controller_always_rewrites_bluetooth_host(self):
         pairing = pair.Pair.__new__(pair.Pair)
-        pairing.pre_existing_devices = mock.Mock()
+        pairing.bt_devices = {"00:15:83:ef:21:57": []}
+        pairing.update_adapters = mock.Mock()
         pairing.get_lowest_bt_device = mock.Mock(
             return_value="00:15:83:ef:21:57"
         )
@@ -25,8 +26,25 @@ class PairTest(unittest.TestCase):
         ) as pair_controller:
             self.assertTrue(pairing.pair_move(controller))
 
-        pairing.pre_existing_devices.assert_called_once_with()
+        pairing.update_adapters.assert_called_once_with()
         pair_controller.assert_called_once_with("00:15:83:ef:21:57")
+        self.assertEqual(
+            pairing.bt_devices["00:15:83:ef:21:57"],
+            ["00:06:f7:97:4d:57"],
+        )
+
+    @mock.patch.object(pair.jm_dbus, "get_hci_dict")
+    def test_adapter_refresh_removes_unplugged_addresses(self, get_hci_dict):
+        get_hci_dict.return_value = {"hci0": "8C:68:8B:C3:DD:47"}
+        pairing = pair.Pair.__new__(pair.Pair)
+        pairing.hci_dict = {"hci0": "00:15:83:EF:21:57"}
+        pairing.bt_devices = {"00:15:83:EF:21:57": ["old-controller"]}
+        pairing.pre_existing_devices = mock.Mock()
+
+        pairing.update_adapters()
+
+        self.assertEqual(pairing.bt_devices, {"8C:68:8B:C3:DD:47": []})
+        pairing.pre_existing_devices.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/webui.py
+++ b/webui.py
@@ -1,5 +1,7 @@
 from multiprocessing import Queue, Manager, Process
 import socket
+import subprocess
+from pathlib import Path
 from flask import Flask, render_template, request, redirect, url_for, flash
 from wtforms import Form, SelectField, SelectMultipleField, BooleanField, widgets, FieldList
 from os import environ
@@ -9,11 +11,15 @@ import json
 import yaml
 import logging
 import runtime_platform
+import bluetooth_diagnostics
 from system_power import request_system_power
 
 if platform == "linux" or platform == "linux2":
+    import bluetooth_roles
+    import jm_dbus
     import psmove_dbus
 else:
+    bluetooth_roles = None
     psmove_dbus = None
 
 log = logging.getLogger('werkzeug')
@@ -70,11 +76,12 @@ class SettingsForm(Form):
     random_team_size = SelectField('size of random teams',choices=[(2,'2'),(3,'3'),(4,'4'),(5,'5'),(6,'6')],coerce=int)
 
 class WebUI():
-    def __init__(self, command_queue=Queue(), ns=None):
+    def __init__(self, command_queue=Queue(), ns=None, controller_manager_instance=None):
 
         self.app = Flask(__name__)
         self.app.secret_key="MAGFest is a donut"
         self.command_queue = command_queue
+        self.controller_manager = controller_manager_instance
         if ns == None:
 
             self.ns = Manager().Namespace()
@@ -99,7 +106,21 @@ class WebUI():
         self.app.add_url_rule('/killgame','kill_game',self.kill_game)
         self.app.add_url_rule('/updateStatus','update',self.update)
         self.app.add_url_rule('/battery','battery_status',self.battery_status)
-        self.app.add_url_rule('/debug/controllers','controller_debug',self.controller_debug)
+        self.app.add_url_rule('/debug','debug',self.controller_debug)
+        self.app.add_url_rule('/debug/controllers','controller_debug_legacy',self.controller_debug_legacy)
+        self.app.add_url_rule('/debug/data','debug_data',self.debug_data)
+        self.app.add_url_rule(
+            '/debug/reset-bluetooth',
+            'reset_bluetooth',
+            self.reset_bluetooth,
+            methods=['POST'],
+        )
+        self.app.add_url_rule(
+            '/debug/restart-joustmania',
+            'restart_joustmania',
+            self.restart_joustmania,
+            methods=['POST'],
+        )
         self.app.add_url_rule('/settings','settings',self.settings, methods=['GET','POST'])
         self.app.add_url_rule('/rand<num_teams>','randomize',self.randomize_teams)
         self.app.add_url_rule('/power','power',self.power)
@@ -151,7 +172,61 @@ class WebUI():
     def battery_status(self):
         return self.controller_debug()
 
-    def controller_debug(self):
+    def controller_debug_legacy(self):
+        return redirect(url_for('debug'))
+
+    def debug_data(self):
+        return {
+            "adapters": bluetooth_diagnostics.get_adapters(),
+            "controllers": self._controller_debug_data(),
+        }
+
+    def reset_bluetooth(self):
+        """Launch the existing reset workflow after this response is sent.
+
+        The workflow deliberately stops this WebUI along with the game, clears
+        saved PS Move registrations, and starts JoustMania again. A detached,
+        delayed process lets the browser receive the confirmation page first.
+        """
+        reset_script = Path(__file__).resolve().parent / 'reset_psmove_connections.sh'
+        if not reset_script.is_file():
+            return 'Bluetooth reset script was not found.', 500
+        # Do not inherit Supervisor's stdout pipe: stopping JoustMania closes
+        # that pipe and would kill clear_devices.py with BrokenPipeError.
+        reset_log = open('/var/log/joustmania-bluetooth-reset.log', 'a')
+        try:
+            subprocess.Popen(
+                ['/bin/bash', '-c', 'sleep 1; exec "$0"', str(reset_script)],
+                stdin=subprocess.DEVNULL,
+                stdout=reset_log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                close_fds=True,
+            )
+        finally:
+            reset_log.close()
+        return render_template('bluetooth_reset.html')
+
+    def restart_joustmania(self):
+        """Restart only the Supervisor-managed JoustMania application."""
+        restart_script = Path(__file__).resolve().parent / 'restart_joustmania.sh'
+        if not restart_script.is_file():
+            return 'JoustMania restart script was not found.', 500
+        restart_log = open('/var/log/joustmania-restart.log', 'a')
+        try:
+            subprocess.Popen(
+                ['/bin/bash', '-c', 'sleep 1; exec "$0"', str(restart_script)],
+                stdin=subprocess.DEVNULL,
+                stdout=restart_log,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                close_fds=True,
+            )
+        finally:
+            restart_log.close()
+        return render_template('joustmania_restart.html')
+
+    def _controller_debug_data(self):
         battery_status = {
             str(address).upper(): level
             for address, level in dict(self.ns.battery_status).items()
@@ -160,6 +235,19 @@ class WebUI():
             str(address).upper(): value
             for address, value in dict(getattr(self.ns, 'out_moves', {})).items()
         }
+        update_counts = {
+            str(address).upper(): int(value)
+            for address, value in dict(
+                getattr(self.ns, 'controller_update_counts', {})
+            ).items()
+        }
+        if self.controller_manager is not None:
+            update_counts = {
+                str(self.controller_manager.index_to_serial[index]).upper(): int(
+                    self.controller_manager.state_sequence[index] // 2
+                )
+                for index in self.controller_manager.active_controller_indices()
+            }
 
         if psmove_dbus is not None:
             controllers = psmove_dbus.get_registered_controllers()
@@ -182,6 +270,23 @@ class WebUI():
                 for address in battery_status
             ]
 
+        # One controller can retain registrations under multiple adapter
+        # addresses after dongles are swapped. Display the physical controller
+        # once, preferring its current live/connected BlueZ object over saved
+        # registrations belonging to unavailable adapters.
+        controllers_by_address = {}
+        for controller in controllers:
+            address = controller['address'].upper()
+            existing = controllers_by_address.get(address)
+            rank = (
+                bool(controller['connected']),
+                bool(controller['loaded']),
+                controller['adapter'] != 'unknown',
+            )
+            if existing is None or rank > existing[0]:
+                controllers_by_address[address] = (rank, controller)
+        controllers = [item[1] for item in controllers_by_address.values()]
+
         for controller in controllers:
             address = controller['address'].upper()
             battery = battery_status.get(address)
@@ -194,6 +299,23 @@ class WebUI():
             controller['active'] = (
                 None if address not in out_moves else out_moves[address] == 0
             )
+            controller['update_count'] = update_counts.get(address)
+
+        if bluetooth_roles is not None:
+            try:
+                roles = bluetooth_roles.get_connection_roles(
+                    list(jm_dbus.get_hci_dict().keys())
+                )
+            except Exception:
+                roles = {}
+            for controller in controllers:
+                connection = roles.get(controller['address'].upper(), {})
+                controller['role'] = connection.get('role', 'Unavailable')
+                controller['handle'] = connection.get('handle')
+        else:
+            for controller in controllers:
+                controller['role'] = 'Unavailable'
+                controller['handle'] = None
 
         controllers.sort(
             key=lambda controller: (
@@ -202,7 +324,21 @@ class WebUI():
                 controller['address'],
             )
         )
-        return render_template('controller_debug.html', controllers=controllers)
+        return controllers
+
+    def controller_debug(self):
+        controllers = self._controller_debug_data()
+        adapters = bluetooth_diagnostics.get_adapters()
+        for adapter in adapters:
+            adapter['controllers'] = [
+                controller for controller in controllers
+                if controller['adapter'] == adapter['name']
+            ]
+        return render_template(
+            'controller_debug.html',
+            controllers=controllers,
+            adapters=adapters,
+        )
 
     #@app.route('/power')
     def power(self):
@@ -284,10 +420,10 @@ class WebUI():
             team_colors = [color.name for color in team_colors]
             return str(team_colors).replace("'",'"')#JSON is dumb and demands double quotes
 
-def start_web(command_queue, ns):
+def start_web(command_queue, ns, controller_manager_instance=None):
     import setproctitle
     setproctitle.setproctitle(f"JoustMania-WebUI")    
-    webui = WebUI(command_queue,ns)
+    webui = WebUI(command_queue, ns, controller_manager_instance)
     webui.web_loop()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- replace the controller-only debug page with a live system debug dashboard
- group controllers beneath their Bluetooth adapters and report live update rates, connection roles, adapter traffic, hardware identity, and errors
- automatically switch active PS Move links to Peripheral role to avoid the severe ZCM1 update-rate slowdown observed with some Realtek adapters
- refresh and balance adapter selection during USB pairing so hot-plugged controllers do not all fall back to one adapter
- add WebUI actions for Bluetooth reset and JoustMania restart, with safer restart handling
- highlight controller update health as red below 70/s, yellow from 70–80/s, and green above 80/s

## Hardware findings

- Realtek ZCM1 links improved from roughly 65–67 updates/s in Central role to roughly 87–89 updates/s in Peripheral role
- CSR ZCM1 and ZCM2 behavior was less role-sensitive, but automatic Peripheral selection keeps behavior consistent across adapters

## Verification

- `PYTHONPATH=/home/aaron/psmoveapi/bindings/python PSMOVEAPI_LIBRARY_PATH=/home/aaron/psmoveapi/build ./venv/bin/python -m unittest discover -p 'test_*.py'`
- 29 tests passed
- `git diff --check` passed
- exercised live with multiple PS Move controllers across Realtek and CSR Bluetooth adapters

![Live Bluetooth system debug dashboard](https://github.com/user-attachments/assets/363414af-fbf9-45d7-bcca-7e30cf6c4131)