### PR TITLE
Allow startup without Bluetooth and restore robot announcements

### DIFF
--- a/games/game.py
+++ b/games/game.py
@@ -3,7 +3,7 @@ import os
 import common, colors
 from common import Status
 from colors import Colors
-from piaudio import Audio
+from piaudio import Audio, speak
 import numpy
 import random
 import logging
@@ -295,14 +295,16 @@ class Game():
             win_team_name = self.team_colors[self.winning_team].name
             if win_team_name == 'Pink':
                 if self.voice == 'aaron':
-                    os.popen('espeak -ven -p 70 -a 200 "And the winner is ...Pink Team')
+                    speak("And the winner is ...Pink Team")
+                    return
                 else:
                     team_win = Audio('audio/Joust/vox/' + self.voice + '/pink team win.wav')
             elif win_team_name == 'Magenta':
                 team_win = Audio('audio/Joust/vox/' + self.voice + '/magenta team win.wav')
             elif win_team_name == 'Orange':
                 if self.voice == 'aaron':
-                    os.popen('espeak -ven -p 70 -a 200 "And the winner is ...Orange Team')
+                    speak("And the winner is ...Orange Team")
+                    return
                 else:
                     team_win = Audio('audio/Joust/vox/' + self.voice + '/orange team win.wav')
             elif win_team_name == 'Yellow':
@@ -317,7 +319,8 @@ class Game():
                 team_win = Audio('audio/Joust/vox/' + self.voice + '/red team win.wav')
             elif win_team_name == 'Purple':
                 if self.voice == 'aaron':
-                    os.popen('espeak -ven -p 70 -a 200 "And the winner is ...Purple Team')
+                    speak("And the winner is ...Purple Team")
+                    return
                 else:
                     team_win = Audio('audio/Joust/vox/' + self.voice + '/purple team win.wav')
             else:

--- a/jm_dbus.py
+++ b/jm_dbus.py
@@ -44,9 +44,13 @@ def get_hci_dict():
     """
     for attempt in range(2):
         try:
-            root = ensure_process_bus().get_object(ORG_BLUEZ, '/')
+            bus = ensure_process_bus()
+            # Do not auto-start absent BlueZ: activation can block for 25 seconds.
+            if not bus.name_has_owner(ORG_BLUEZ):
+                return {}
+            root = bus.get_object(ORG_BLUEZ, '/', introspect=False)
             manager = dbus.Interface(root, 'org.freedesktop.DBus.ObjectManager')
-            objects = manager.GetManagedObjects()
+            objects = manager.GetManagedObjects(timeout=1)
             return {
                 str(path).rsplit('/', 1)[-1]: str(properties['Address'])
                 for path, interfaces in objects.items()

--- a/pair.py
+++ b/pair.py
@@ -1,11 +1,14 @@
 import controller_manager
 import os
+import logging
 
 from sys import platform
 if platform == "linux" or platform == "linux2":
     import jm_dbus
+    from dbus import DBusException
 elif platform == "windows" or platform == "win32":
     import win_jm_dbus as jm_dbus
+    DBusException = OSError
     
 import update
 
@@ -15,14 +18,9 @@ class Pair():
     """
     def __init__(self):
         """Use DBus to find bluetooth controllers"""
-        self.hci_dict = jm_dbus.get_hci_dict()
-
-        devices = self.hci_dict.values()
+        self.hci_dict = {}
         self.bt_devices = {}
-        for device in devices:
-            self.bt_devices[device] = []
-
-        self.pre_existing_devices()
+        self.update_adapters()
 
     def pre_existing_devices(self):
         """
@@ -41,7 +39,11 @@ class Pair():
         """
         Rescan for bluetooth adapters that may not have existed on program launch
         """
-        self.hci_dict = jm_dbus.get_hci_dict()
+        try:
+            self.hci_dict = jm_dbus.get_hci_dict()
+        except DBusException as error:
+            logging.getLogger(__name__).warning("Bluetooth unavailable: %s", error)
+            self.hci_dict = {}
 
         # Remove unplugged adapters as well as adding new ones. Otherwise a
         # hot-swap can leave pairing aimed at an address that no longer exists,
@@ -51,7 +53,12 @@ class Pair():
             for addr in self.hci_dict.values()
         }
 
-        self.pre_existing_devices()
+        try:
+            self.pre_existing_devices()
+        except DBusException:
+            # An adapter can disappear between discovery and enumeration.
+            self.hci_dict = {}
+            self.bt_devices = {}
 
     def get_lowest_bt_device(self):
         num = 9999999
@@ -75,6 +82,8 @@ class Pair():
                 # still stores this Pi as its Bluetooth host. Pairing over USB
                 # rewrites that address after use with another computer.
                 host_address = self.get_lowest_bt_device()
+                if not host_address:
+                    return False
                 paired = controller_manager.pair_controller(host_address)
                 if paired:
                     # BlueZ may need a few seconds to publish the registration.

--- a/piaudio.py
+++ b/piaudio.py
@@ -1,4 +1,8 @@
 import asyncio
+import shutil
+import tempfile
+import subprocess
+import logging
 import wave
 import functools
 import io
@@ -281,3 +285,44 @@ class DummyMusic:
 
 def InitAudio():
     pygame.mixer.init(47000, -16, 2 , 4096)
+
+
+@functools.lru_cache(maxsize=16)
+def _robot_voice_sample(message):
+    engine = shutil.which("espeak") or shutil.which("espeak-ng")
+    if not engine:
+        return None
+    # stdout WAV headers use an unknown length, which SDL can interpret as
+    # a huge allocation. A file gives espeak a seekable, correctly sized WAV.
+    with tempfile.NamedTemporaryFile(suffix=".wav") as output:
+        subprocess.run(
+            [engine, "-w", output.name, "-ven", "-p", "70", message],
+            capture_output=True, check=True, timeout=5,
+        )
+        # Some USB speakers stay asleep through digital silence. A quiet
+        # attention tone wakes the output before the first spoken syllable.
+        with wave.open(output.name, "rb") as source:
+            params = source.getparams()
+            frames = source.readframes(source.getnframes())
+        padded = io.BytesIO()
+        with wave.open(padded, "wb") as target:
+            target.setparams(params)
+            tone_frames = int(params.framerate * 0.3)
+            phase = numpy.arange(tone_frames) / params.framerate
+            envelope = numpy.minimum(phase / 0.02, (0.3 - phase) / 0.02).clip(0, 1)
+            tone = (numpy.sin(2 * numpy.pi * 660 * phase) * envelope * 2500).astype('<i2')
+            target.writeframes(tone.tobytes())
+            target.writeframes(bytes(int(params.framerate * 0.4) * params.nchannels * params.sampwidth))
+            target.writeframes(frames)
+        padded.seek(0)
+        return pygame.mixer.Sound(file=padded)
+
+
+def speak(message):
+    """Play robot speech through the same mixer/output as game effects."""
+    try:
+        sample = _robot_voice_sample(message)
+        if sample is not None:
+            sample.play()
+    except (OSError, subprocess.SubprocessError, pygame.error) as error:
+        logging.getLogger(__name__).warning("Robot voice unavailable: %s", error)

--- a/piparty.py
+++ b/piparty.py
@@ -43,7 +43,7 @@ from common import Button, Games, Status, Sensitivity
 import yaml
 import time, random, os.path
 from datetime import datetime
-from piaudio import Music, Audio, InitAudio
+from piaudio import Music, Audio, InitAudio, speak
 from enum import Enum
 from multiprocessing import Process, Value, Array, Queue, Manager
 from games import joust_ffa, joust_teams, joust_random_teams, joust_non_stop, traitor, werewolf, zombie, commander, swapper, tournament, speed_bomb, fight_club
@@ -404,6 +404,8 @@ class Menu():
         self.game_mode = Games[self.ns.settings['current_game']] # Get game mode from ns (which is shared with web admin)
         self.old_game_mode = self.game_mode #Previous game mode
         self.pair = pair.Pair() # Start bluetooth pairing
+        self.bluetooth_missing = False
+        self.bluetooth_pairing_notices = set()
 
         self.menu = Value('i', 1) # Whether in the menu or not (1 - Menu, 0 - Game)
         self.controller_game_mode = Value('i',1) # Game mode shared across all processes
@@ -461,6 +463,15 @@ class Menu():
                 logger.warning("Bluetooth is temporarily unavailable: %s", error)
                 return
 
+            missing = not bt_hcis
+            if missing and not self.bluetooth_missing:
+                logger.warning("Bluetooth is not available.")
+                if self.ns.settings['play_audio']:
+                    speak("Bluetooth is not available.")
+            if not missing:
+                self.bluetooth_pairing_notices.clear()
+            self.bluetooth_missing = missing
+
             for hci in bt_hcis:
                 for attempt in range(1):
                     try:
@@ -486,6 +497,13 @@ class Menu():
             if controller.usb and not controller.bluetooth:
                 if move_serial not in self.paired_moves:
                     logger.debug("Pairing USB move: {}".format(move_serial))
+                    if platform in ("linux", "linux2") and self.bluetooth_missing:
+                        if move_serial not in self.bluetooth_pairing_notices:
+                            self.bluetooth_pairing_notices.add(move_serial)
+                            logger.warning("Cannot pair %s: no Bluetooth adapter connected", move_serial)
+                            if self.ns.settings['play_audio']:
+                                speak("Bluetooth is not available.")
+                        return
                     if self.pair.pair_move(controller):
                         controller.set_color(255, 255, 255)
                         controller.set_rumble(0)
@@ -1099,7 +1117,7 @@ class Menu():
             Audio('audio/Menu/vox/' + self.ns.settings['menu_voice'] + '/Tournament-instructions.wav').start_effect_and_wait()
         if self.game_mode == Games.FightClub:
             if self.ns.settings['menu_voice'] == 'aaron':
-                os.popen('espeak -ven -p 70 -a 200 "Two players fight, the winner must defend their title, the player with the highest score wins')
+                speak("Two players fight, the winner must defend their title, the player with the highest score wins")
             else:
                 Audio('audio/Menu/vox/' + self.ns.settings['menu_voice'] + '/Fightclub-instructions.wav').start_effect_and_wait()
             time.sleep(5)

--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ setup() {
         libportmidi-dev portaudio19-dev \
         libsdl-image1.2-dev libsdl-ttf2.0-dev \
         libblas-dev liblapack-dev \
-        bluez bluez-tools iptables rfkill supervisor cmake ffmpeg \
+        bluez bluez-tools iptables rfkill supervisor cmake ffmpeg espeak \
         libudev-dev libbluetooth-dev \
         alsa-utils alsa-tools libasound2-dev libsdl2-mixer-2.0-0 \
         python-dbus-dev python3-dbus libdbus-glib-1-dev usbutils libopenblas-dev \

--- a/templates/joustmania.html
+++ b/templates/joustmania.html
@@ -103,6 +103,7 @@ function updateStatus() {
         timeout: 2000,
         success: function(rawdata) {
             var info = JSON.parse(rawdata);
+            $('#bluetooth_notice').text(info.bluetooth_message || '').toggle(Boolean(info.bluetooth_message));
             $('.main_status').show();
             $('#game_mode').text(info.game_mode);
             $('.info_box').hide();
@@ -201,6 +202,7 @@ $(document).ready(function() {
 {% endblock %}
 
 {% block body %}
+<div id="bluetooth_notice" role="status" style="display:none; padding:1em; background:#fff3cd; color:#664d03;"></div>
 <div class="main_status">
     Current mode: <span id="game_mode">Joust Null</span><br />
 </div>

--- a/test_optional_bluetooth.py
+++ b/test_optional_bluetooth.py
@@ -1,0 +1,73 @@
+import json
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import jm_dbus
+import pair
+import webui
+
+
+class OptionalBluetoothTest(unittest.TestCase):
+    @mock.patch.object(jm_dbus, 'ensure_process_bus')
+    def test_absent_service_does_not_attempt_activation(self, connect):
+        connect.return_value.name_has_owner.return_value = False
+        self.assertEqual(jm_dbus.get_hci_dict(), {})
+        connect.return_value.get_object.assert_not_called()
+
+    @mock.patch.object(pair.jm_dbus, 'get_hci_dict', return_value={})
+    @mock.patch.object(pair.controller_manager, 'pair_controller')
+    def test_no_adapter_skips_native_pairing(self, native_pair, discover):
+        pairing = pair.Pair()
+        controller = SimpleNamespace(serial='test', usb=True, bluetooth=False)
+        self.assertFalse(pairing.pair_move(controller))
+        native_pair.assert_not_called()
+
+    @mock.patch.object(pair.jm_dbus, 'get_hci_dict')
+    def test_service_failure_does_not_prevent_initialization(self, discover):
+        discover.side_effect = jm_dbus.dbus.DBusException('Service unavailable')
+        self.assertEqual(pair.Pair().bt_devices, {})
+
+    @mock.patch.object(pair.jm_dbus, 'get_hci_dict')
+    @mock.patch.object(pair.Pair, 'pre_existing_devices')
+    def test_adapter_can_be_added_after_startup(self, enumerate_devices, discover):
+        discover.side_effect = [{}, {'hci0': 'AA:BB:CC:DD:EE:FF'}]
+        pairing = pair.Pair()
+        pairing.update_adapters()
+        self.assertEqual(pairing.get_lowest_bt_device(), 'AA:BB:CC:DD:EE:FF')
+
+    @mock.patch.object(webui.jm_dbus, 'get_hci_dict')
+    def test_web_warning_clears_when_adapter_returns(self, discover):
+        ui = webui.WebUI.__new__(webui.WebUI)
+        ui.ns = SimpleNamespace(status={'game_status': 'menu'})
+        discover.side_effect = [{}, {'hci0': 'AA:BB:CC:DD:EE:FF'}]
+        self.assertIn('No Bluetooth', json.loads(ui.update())['bluetooth_message'])
+        self.assertEqual(json.loads(ui.update())['bluetooth_message'], '')
+        self.assertEqual(ui.ns.status, {'game_status': 'menu'})
+
+class RobotVoiceTest(unittest.TestCase):
+    def test_real_espeak_generates_bounded_playable_audio(self):
+        import os
+        import shutil
+        import piaudio
+        if not (shutil.which('espeak') or shutil.which('espeak-ng')):
+            self.skipTest('Speech engine not installed')
+        with mock.patch.dict(os.environ, {'SDL_AUDIODRIVER': 'dummy'}):
+            piaudio.InitAudio()
+            try:
+                sample = piaudio._robot_voice_sample('Robot voice regression test.')
+                self.assertGreater(sample.get_length(), 0)
+                self.assertLess(sample.get_length(), 10)
+                samples = piaudio.pygame.sndarray.array(sample)
+                rate = piaudio.pygame.mixer.get_init()[0]
+                self.assertTrue(samples[:int(rate * 0.3)].any())
+                self.assertFalse(samples[int(rate * 0.35):int(rate * 0.65)].any())
+                self.assertTrue(samples[int(rate * 0.7):].any())
+                self.assertIsNotNone(sample.play())
+            finally:
+                piaudio._robot_voice_sample.cache_clear()
+                piaudio.pygame.mixer.quit()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/webui.py
+++ b/webui.py
@@ -145,7 +145,16 @@ class WebUI():
 
     #@app.route('/updateStatus')
     def update(self):
-        return json.dumps(self.ns.status)
+        status = dict(self.ns.status)
+        if platform in ("linux", "linux2"):
+            try:
+                status['bluetooth_message'] = (
+                    "" if jm_dbus.get_hci_dict() else
+                    "No Bluetooth adapter connected. Connect an adapter to pair controllers."
+                )
+            except jm_dbus.dbus.DBusException:
+                status['bluetooth_message'] = "Bluetooth is unavailable. Controller pairing is temporarily disabled."
+        return json.dumps(status)
         
         
     #@app.route('/changemodestr')


### PR DESCRIPTION
JoustMania could stop during Bluetooth initialization before starting music, while its web UI stayed alive. Allow startup without BlueZ or a connected adapter, skip native pairing when no host is available, and show a web warning that clears when an adapter returns. Announce “Bluetooth is not available” at startup and on an unavailable pairing attempt.

Restore robot speech by installing espeak in setup.sh and routing synthesized WAV audio through the game mixer. Replace broken shell commands in legacy announcements, use seekable WAV output to avoid SDL's excessive allocation from streaming headers, and precede speech with a quiet attention tone to address clipped first syllables on the USB speaker.

Validation:
- 15 targeted tests cover absent BlueZ, unavailable pairing, adapter recovery, web warning recovery, audio resampling, Bluetooth roles, and real espeak synthesis/playback with a bounded WAV and attention tone.
- setup.sh shell syntax and git diff whitespace checks pass.
- Live Raspberry Pi startup reaches the menu; the web API reports the missing-adapter warning.
- User confirmed music and robot speech reach the USB speaker, and that the attention tone fixes the clipped announcement.
