### PR TITLE
Add Wi-Fi hotspot toggle and status to the debug page

### DIFF
--- a/access_point.py
+++ b/access_point.py
@@ -1,0 +1,68 @@
+"""Control the existing Wi-Fi hotspot scripts without blocking web responses."""
+from pathlib import Path
+import shutil
+import subprocess
+import threading
+import time
+
+APP_DIR = Path(__file__).resolve().parent
+
+
+class AccessPoint:
+    def __init__(self):
+        self.lock = threading.RLock()
+        self.busy = False
+        self.error = ''
+        self.cached = None
+        self.checked_at = 0
+
+    def status(self):
+        with self.lock:
+            if self.cached is None or time.monotonic() - self.checked_at >= 3:
+                state = {'enabled': None, 'available': False}
+                if shutil.which('nmcli'):
+                    try:
+                        result = subprocess.run(
+                            ['nmcli', '-t', '-f', 'NAME', 'connection', 'show', '--active'],
+                            capture_output=True, text=True, check=True, timeout=2,
+                        )
+                        state = {'enabled': 'Hotspot' in result.stdout.splitlines(), 'available': True}
+                    except (OSError, subprocess.SubprocessError):
+                        pass
+                self.cached = state
+                self.checked_at = time.monotonic()
+            return dict(self.cached, busy=self.busy, error=self.error)
+
+    def change(self, action):
+        if action not in ('enable', 'disable'):
+            raise ValueError('Choose enable or disable.')
+        with self.lock:
+            if self.busy:
+                raise RuntimeError('A hotspot change is already in progress.')
+            if not self.status()['available']:
+                raise RuntimeError('Wi-Fi hotspot controls require NetworkManager.')
+            self.busy = True
+            self.error = ''
+            threading.Thread(target=self._run, args=(action,), daemon=True).start()
+
+    def _run(self, action):
+        try:
+            # Deliver the response before switching the network used by the browser.
+            time.sleep(1)
+            subprocess.run(
+                ['sudo', '-n', '/bin/bash', str(APP_DIR / (action + '_ap.sh'))],
+                cwd=APP_DIR, capture_output=True, text=True, check=True, timeout=90,
+            )
+        except subprocess.CalledProcessError as error:
+            with self.lock:
+                self.error = (error.stderr or error.stdout or 'Hotspot change failed.').strip()[-500:]
+        except (OSError, subprocess.TimeoutExpired) as error:
+            with self.lock:
+                self.error = str(error)
+        finally:
+            with self.lock:
+                self.busy = False
+                self.cached = None
+
+
+access_point = AccessPoint()

--- a/disable_ap.sh
+++ b/disable_ap.sh
@@ -1,25 +1,15 @@
 #!/bin/bash
+set -e
 
-if [ $UID -ne 0 ]; then
-  echo "Not root. Using sudo."
-  exec sudo $0
+if [ "$UID" -ne 0 ]; then
+    exec sudo -n /bin/bash "$0" "$@"
 fi
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
 
-
-if [ ! -f ./apfiles/ap_active ]
-	then echo "AP not active... ending"
-	exit
+# Query NetworkManager rather than relying on a potentially stale marker.
+profiles=$(nmcli -t -f NAME connection show)
+if grep -Fxq Hotspot <<< "$profiles"; then
+    nmcli -w 20 connection delete Hotspot
 fi
-
-rm ./apfiles/ap_active
-
-echo "Deleting ad-hoc network, This pi should now reconnect back to the internet"
-nmcli con delete Hotspot
-
-#removing dnsmasq (for http://joust.mania access)
-rm /etc/NetworkManager/dnsmasq-shared.d/joustmania.conf
-
-
-echo ">>> DONE <<<"
-
-
+rm -f /etc/NetworkManager/dnsmasq-shared.d/joustmania.conf ./apfiles/ap_active
+echo "Hotspot disabled. The Pi can reconnect to its saved Wi-Fi network."

--- a/enable_ap.sh
+++ b/enable_ap.sh
@@ -1,40 +1,25 @@
 #!/bin/bash
+set -e
 
-
-if [ $UID -ne 0 ]; then
-  echo "Not root. Using sudo."
-  exec sudo $0
+if [ "$UID" -ne 0 ]; then
+    exec sudo -n /bin/bash "$0" "$@"
 fi
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
 
-if [ -f ./apfiles/ap_active ]
-	then echo "Script already run"
-	exit
-fi
-
-touch ./apfiles/ap_active
-
-#Copy over dnsmasq file so that http://joust.mania redirects to the webUI
-echo "Copying dnsmasq configuration"
+# Copy DNS settings before activating the hotspot.
+mkdir -p /etc/NetworkManager/dnsmasq-shared.d
 cp ./apfiles/joustmania.conf /etc/NetworkManager/dnsmasq-shared.d/joustmania.conf
 
-echo "Create and enable wifi ad-hoc network"
-#(note lowercase joustmania ssid does not work for some reason)
-nmcli device wifi hotspot ifname wlan0 con-name Hotspot ssid JoustMania password "joustpass"
-
-echo "Enable ad-hoc network as default on boot... "
+profiles=$(nmcli -t -f NAME connection show)
+if grep -Fxq Hotspot <<< "$profiles"; then
+    nmcli -w 20 connection up Hotspot
+else
+    nmcli -w 20 device wifi hotspot ifname wlan0 con-name Hotspot ssid JoustMania password "joustpass"
+fi
 nmcli connection modify Hotspot connection.autoconnect true
-
-echo "Disable power save feature on wifi..."
 nmcli connection modify Hotspot 802-11-wireless.powersave 2
-
-echo "Enable wake-on-wlan..."
 nmcli connection modify Hotspot 802-11-wireless.wake-on-wlan 2
 
-echo "You should now be able to see and connect to JoustMania ssid on mobile (password: joustpass), and browse to the webui at http://joust.mania"
-
-echo ">>> DONE <<<"
-
-
-
-
-
+# Only record success after NetworkManager has completed the operation.
+touch ./apfiles/ap_active
+echo "Connect to JoustMania (password: joustpass), then open http://joust.mania"

--- a/templates/controller_debug.html
+++ b/templates/controller_debug.html
@@ -102,6 +102,18 @@
         <table class="controller-table"><tbody class="controller-status-body" data-for-adapter="unknown"></tbody></table>
     </div>
     <p><a href="/"><button type="button">Go Back</button></a></p>
+    <section aria-labelledby="hotspot-heading">
+        <h3 id="hotspot-heading">Wi-Fi Hotspot</h3>
+        <p role="status" id="hotspot-status">{{ 'Enabled' if access_point.enabled else ('Disabled' if access_point.available else 'Unavailable') }}</p>
+        <form id="hotspot-form" action="/debug/access-point" method="POST">
+            <input id="hotspot-action" type="hidden" name="action" value="{{ 'disable' if access_point.enabled else 'enable' }}">
+            <button id="hotspot-button" type="submit" {% if not access_point.available or access_point.busy %}disabled{% endif %}>{{ 'Disable' if access_point.enabled else 'Enable' }} Wi-Fi Hotspot</button>
+        </form>
+        <p class="diagnostic-note">Enabling switches the Pi's Wi-Fi to the <strong>JoustMania</strong> hotspot.
+        Connect with password <strong>joustpass</strong>, then open <a href="http://joust.mania">http://joust.mania</a>.
+        Disabling lets the Pi reconnect to its saved Wi-Fi network. This page may disconnect when switching networks.</p>
+        <p id="hotspot-error" role="alert"></p>
+    </section>
     <form action="/debug/restart-joustmania" method="POST"
           onsubmit="return confirm('Restart JoustMania? This stops the current game but does not reboot the computer or clear Bluetooth connections.');">
         <button type="submit">Restart JoustMania</button>
@@ -116,6 +128,32 @@
 <script>
 (function () {
     let lastTime = Date.now();
+    let hotspotPending = false;
+    function renderHotspot(state) {
+        document.getElementById('hotspot-status').textContent = state.busy ? 'Changing Wi-Fi hotspot…' :
+            (!state.available ? 'Unavailable' : (state.enabled ? 'Enabled' : 'Disabled'));
+        document.getElementById('hotspot-action').value = state.enabled ? 'disable' : 'enable';
+        document.getElementById('hotspot-button').textContent = (state.enabled ? 'Disable' : 'Enable') + ' Wi-Fi Hotspot';
+        document.getElementById('hotspot-button').disabled = hotspotPending || state.busy || !state.available;
+        document.getElementById('hotspot-error').textContent = state.error || '';
+    }
+    document.getElementById('hotspot-form').addEventListener('submit', function (event) {
+        event.preventDefault();
+        hotspotPending = true;
+        document.getElementById('hotspot-button').disabled = true;
+        document.getElementById('hotspot-status').textContent = 'Changing Wi-Fi hotspot…';
+        fetch('/debug/access-point', {method: 'POST', body: new URLSearchParams(new FormData(this))})
+            .then(function (response) {
+                return response.json().then(function (data) {
+                    if (!response.ok) throw new Error(data.error || 'Hotspot change failed.');
+                    hotspotPending = false;
+                    renderHotspot(data);
+                });
+            }).catch(function (error) {
+                hotspotPending = false;
+                document.getElementById('hotspot-error').textContent = error.message + ' If Wi-Fi changed, reconnect and reload this page.';
+            });
+    });
     const controllerLast = {};
     function cell(row, value, className) {
         const item = document.createElement('td');
@@ -179,6 +217,7 @@
     }
     window.setInterval(function () {
         fetch('/debug/data', {cache: 'no-store'}).then(function (response) { return response.json(); }).then(function (data) {
+            renderHotspot(data.access_point);
             const now = Date.now();
             const seconds = Math.max((now - lastTime) / 1000, 0.001);
             const adapterRows = Array.from(document.querySelectorAll('#bluetooth-adapter-body [data-adapter]'));

--- a/test_access_point.py
+++ b/test_access_point.py
@@ -1,0 +1,90 @@
+import subprocess
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import access_point
+import webui
+
+
+class AccessPointTest(unittest.TestCase):
+    @mock.patch.object(access_point.shutil, 'which', return_value='/usr/bin/nmcli')
+    @mock.patch.object(access_point.subprocess, 'run')
+    def test_status_uses_active_network_not_marker(self, run, which):
+        controller = access_point.AccessPoint()
+        run.return_value.stdout = 'Home Wi-Fi\n'
+        self.assertFalse(controller.status()['enabled'])
+        controller.cached = None
+        run.return_value.stdout = 'Hotspot\n'
+        self.assertTrue(controller.status()['enabled'])
+        controller.status()
+        self.assertEqual(run.call_count, 2)  # Polling is cached.
+
+    @mock.patch.object(access_point.shutil, 'which', return_value='/usr/bin/nmcli')
+    @mock.patch.object(access_point.subprocess, 'run', side_effect=subprocess.TimeoutExpired('nmcli', 2))
+    def test_failed_status_is_unknown_not_disabled(self, run, which):
+        state = access_point.AccessPoint().status()
+        self.assertIsNone(state['enabled'])
+        self.assertFalse(state['available'])
+
+    @mock.patch.object(access_point.threading, 'Thread')
+    def test_changes_are_validated_and_serialized(self, thread):
+        controller = access_point.AccessPoint()
+        with mock.patch.object(controller, 'status', return_value={'available': True}):
+            with self.assertRaises(ValueError):
+                controller.change('../../bad')
+            controller.change('enable')
+            self.assertTrue(controller.busy)
+            thread.return_value.start.assert_called_once()
+            with self.assertRaises(RuntimeError):
+                controller.change('disable')
+
+    @mock.patch.object(access_point.time, 'sleep')
+    @mock.patch.object(access_point.subprocess, 'run')
+    def test_script_failure_is_reported_and_unlocks_controls(self, run, sleep):
+        controller = access_point.AccessPoint()
+        controller.busy = True
+        run.side_effect = subprocess.CalledProcessError(1, 'script', stderr='Wi-Fi unavailable')
+        controller._run('enable')
+        self.assertFalse(controller.busy)
+        self.assertEqual(controller.error, 'Wi-Fi unavailable')
+        self.assertIsNone(controller.cached)
+        self.assertEqual(run.call_args.args[0][-1], str(access_point.APP_DIR / 'enable_ap.sh'))
+        self.assertEqual(run.call_args.kwargs['cwd'], access_point.APP_DIR)
+
+
+class AccessPointWebTest(unittest.TestCase):
+    def setUp(self):
+        self.ui = webui.WebUI(ns=SimpleNamespace(status={}, battery_status={}))
+        self.client = self.ui.app.test_client()
+
+    @mock.patch.object(webui, 'access_point')
+    def test_post_dispatches_explicit_action(self, control):
+        control.status.return_value = {'enabled': False, 'available': True, 'busy': True, 'error': ''}
+        response = self.client.post('/debug/access-point', data={'action': 'enable'})
+        self.assertEqual(response.status_code, 202)
+        control.change.assert_called_once_with('enable')
+        self.assertEqual(self.client.get('/debug/access-point').status_code, 405)
+
+    @mock.patch.object(webui, 'access_point')
+    def test_invalid_action_and_busy_errors(self, control):
+        control.change.side_effect = ValueError('Invalid action')
+        self.assertEqual(self.client.post('/debug/access-point', data={'action': 'bad'}).status_code, 400)
+        control.change.side_effect = RuntimeError('Busy')
+        self.assertEqual(self.client.post('/debug/access-point', data={'action': 'enable'}).status_code, 409)
+
+    @mock.patch.object(webui, 'access_point')
+    @mock.patch.object(webui.bluetooth_diagnostics, 'get_adapters', return_value=[])
+    def test_debug_page_and_poll_show_hotspot_status(self, adapters, control):
+        control.status.return_value = {'enabled': True, 'available': True, 'busy': False, 'error': ''}
+        with mock.patch.object(self.ui, '_controller_debug_data', return_value=[]):
+            response = self.client.get('/debug')
+            self.assertEqual(response.status_code, 200)
+            self.assertIn(b'Disable Wi-Fi Hotspot', response.data)
+            self.assertIn(b'joustpass', response.data)
+            response = self.client.get('/debug/data')
+            self.assertTrue(response.json['access_point']['enabled'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/webui.py
+++ b/webui.py
@@ -12,6 +12,7 @@ import yaml
 import logging
 import runtime_platform
 import bluetooth_diagnostics
+from access_point import access_point
 from system_power import request_system_power
 
 if platform == "linux" or platform == "linux2":
@@ -109,6 +110,7 @@ class WebUI():
         self.app.add_url_rule('/debug','debug',self.controller_debug)
         self.app.add_url_rule('/debug/controllers','controller_debug_legacy',self.controller_debug_legacy)
         self.app.add_url_rule('/debug/data','debug_data',self.debug_data)
+        self.app.add_url_rule('/debug/access-point', 'access_point', self.change_access_point, methods=['POST'])
         self.app.add_url_rule(
             '/debug/reset-bluetooth',
             'reset_bluetooth',
@@ -179,7 +181,17 @@ class WebUI():
         return {
             "adapters": bluetooth_diagnostics.get_adapters(),
             "controllers": self._controller_debug_data(),
+            "access_point": access_point.status(),
         }
+
+    def change_access_point(self):
+        try:
+            access_point.change(request.form.get('action'))
+        except ValueError as error:
+            return {'error': str(error)}, 400
+        except RuntimeError as error:
+            return {'error': str(error)}, 409
+        return access_point.status(), 202
 
     def reset_bluetooth(self):
         """Launch the existing reset workflow after this response is sent.
@@ -336,6 +348,7 @@ class WebUI():
             ]
         return render_template(
             'controller_debug.html',
+            access_point=access_point.status(),
             controllers=controllers,
             adapters=adapters,
         )


### PR DESCRIPTION
Add an Enable/Disable Wi-Fi Hotspot button beside the restart controls on the debug page. Show the active hotspot state from NetworkManager, update it during normal debug polling, and display progress, errors, and instructions for reconnecting to the JoustMania network.

Run the existing access-point scripts in the background so the browser can receive the response before Wi-Fi changes. Serialize change requests, bound command execution, and cache status checks to limit polling overhead. Make the scripts work from any directory, handle existing profiles, and record successful activation only after the commands complete.

Validation:
- Seven focused tests pass on this branch: live status parsing, unavailable NetworkManager, duplicate/invalid requests, script failures, POST routing, and debug page/API rendering.
- 22 related tests passed in the development checkout.
- Shell syntax and git diff checks pass.
- Read-only check on the Pi reports the hotspot disabled. Automated tests mock network mutations; no live Wi-Fi switch was performed for validation.

This PR is independent of the Bluetooth startup and robot voice changes in #377.
