### PR TITLE
Replace forced Peripheral mode with manual controller role controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ Compare both the live rate and how many controllers can connect before choosing.
 
 ### Raspberry Pi memory
 
-A 1 GB Pi can run JoustMania, but other applications and decoded music leave
-little headroom. In our 1 GB Pi test, Chromium alongside JoustMania and Codex led
+A 1 GB Pi can run JoustMania, but plan conservatively: running more than about
+six controllers while also running the web UI in a browser on the Pi may cause
+performance issues. This is a practical caution, not a tested hard limit of six
+controllers. Other applications and decoded music leave little headroom. In our 1 GB Pi test, Chromium alongside JoustMania and Codex led
 to full compressed swap, slow web responses, and audio underruns. Closing
 Chromium substantially improved responsiveness. Use the web UI from a phone or
 another computer instead of running the browser on the Pi during play.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Cool Stuffs!
 
 Hardware
 ---------------------------
-I am currently selling fully set up Joustmania devices (pi5 - 4gb model, case, two long range bluetooth dongles, sd card, power supply, audio-connector, HDMI cables) for $290 with included shipping domestically. If you would like to inquire about purchasing a fully setup Joustmania device, please reach out to joustmaniagame@gmail.com.
+I am currently selling fully set up Joustmania devices (Pi 5 - 2 GB model, case, two long range bluetooth dongles, sd card, power supply, audio-connector, HDMI cables) for $200 with included shipping domestically. If you would like to inquire about purchasing a fully setup Joustmania device, please reach out to joustmaniagame@gmail.com.
 
 If you would like to build your own device you will need the following:
 
@@ -41,14 +41,55 @@ Optional and recommended:
 * Note: we strongly recommend to use this linked TRENDnet brand as it has been tested, other dongles may or may not work/have other issues: https://a.co/d/6GG35Um
 
 Note on Hardware: The internal bluetooth is shorter range and has a slightly higher latency
-The class 1 adapters allow bluetooth connections up to 300+ feet and allow for the gameplay to be smooth, each adapter can connect to 6 to 7 controllers. I've tested this build with four adapters and 18 controllers successfully.
+The class 1 adapters allow bluetooth connections up to 300+ feet and allow for the gameplay to be smooth, some adapters can support 6 to 7 controllers, depending on the Bluetooth roles and hardware. Earlier builds have been tested with four adapters and 18 controllers successfully; see the role and capacity notes below.
 
-On Linux, JoustMania automatically requests the Bluetooth Peripheral role for
-connected PS Move controllers. In testing, some ZCM1 controllers on Realtek
-adapters ran at only about 65 updates per second in Central role, but reached
-about 87–89 updates per second in Peripheral role. ZCM2 controllers normally
-report much higher rates. The live System Debug page shows each controller's
-role and update rate, with rates above 80 updates per second shown in green.
+### Bluetooth roles and controller capacity
+
+JoustMania lets Bluetooth negotiate controller roles automatically. It does not
+force Peripheral when a controller connects or run a loop that changes roles.
+The System Debug page shows each controller's current role and live update rate.
+Use **Switch to Central** or **Switch to Peripheral** beside a connected
+controller to request a one-time change. The page verifies the resulting role
+and reports failures; a controller or adapter can reject a switch.
+
+The **Try All Peripheral** button attempts the change one controller at a time.
+Peripheral mode may improve data rates, but it can reduce simultaneous connection
+capacity. In one test with three CSR8510 A10 adapters, forcing Peripheral limited
+the setup to two connections per adapter. Switching one adapter's connections to
+Central allowed four controllers on that adapter and eight overall. This is a
+result from that setup, not a universal adapter limit. Earlier testing with some
+ZCM1 controllers found around 65 updates/s in Central and 87–89 in Peripheral.
+Compare both the live rate and how many controllers can connect before choosing.
+
+### Raspberry Pi memory
+
+A 1 GB Pi can run JoustMania, but other applications and decoded music leave
+little headroom. In our 1 GB Pi test, Chromium alongside JoustMania and Codex led
+to full compressed swap, slow web responses, and audio underruns. Closing
+Chromium substantially improved responsiveness. Use the web UI from a phone or
+another computer instead of running the browser on the Pi during play.
+
+For reference, these were observed JoustMania process totals in that test:
+
+| State | Resident + swapped memory |
+| --- | ---: |
+| Menu, no controllers | 338 MiB |
+| Menu, one controller | 356 MiB |
+| Menu, two controllers | 368 MiB |
+| Two-player game | About 472 MiB |
+| Three-player game | About 521 MiB |
+
+The first two controllers added roughly 12–17 MiB each to the menu total. A later
+snapshot showed about 18–23 MiB per controller worker, including its share of
+shared memory and swapped pages. These totals use proportional memory accounting
+(PSS + SwapPss), so shared pages are not counted repeatedly. Swapped memory is
+shown before compression; these numbers are not all physical RAM usage.
+Music buffers, game state, and process history change the totals, so do not
+estimate the full requirement from controller count alone.
+
+The 2 GB Pi offering provides more memory headroom than the tested 1 GB model.
+We have not established a maximum controller count from this memory test;
+Bluetooth adapter capacity and controller update rates must also be checked.
 
 Optional:
 
@@ -169,6 +210,12 @@ For further settings such as turning off audio (play_audio) or changing the colo
 
 Web Interface
 ---------------------------------
+The **System Debug** page includes controller role controls, application and
+Bluetooth reset buttons, and an **Enable/Disable Wi-Fi Hotspot** button. Hotspot
+status comes from NetworkManager and shows whether the hotspot is currently
+active. Changes show progress or errors and may disconnect the browser while
+the Pi switches Wi-Fi networks. The shell commands below remain available.
+
 Joustmania can also be controlled via a web browser on your laptop or smartphone. If your Pi is on a network, use the IP address of your Pi (for example, http://192.168.1.xxx/). Alternatively, you can turn your Pi in to an access point and connect your device directly to it. To enable this,  run the command
 ```
 sudo ./enable_ap.sh

--- a/bluetooth_roles.py
+++ b/bluetooth_roles.py
@@ -1,4 +1,4 @@
-"""Inspect and optimize Bluetooth Classic roles for PS Move connections."""
+"""Inspect Bluetooth Classic roles and perform explicit user-requested switches."""
 
 import re
 import subprocess
@@ -36,39 +36,6 @@ def get_connection_roles(adapter_names):
     return connections
 
 
-def ensure_peripheral(address, adapter_names, attempts=5, retry_delay=0.2):
-    """Best-effort switch of one live connection to the local Peripheral role."""
-    address = address.upper()
-    last_connection = None
-    for attempt in range(attempts):
-        connection = get_connection_roles(adapter_names).get(address)
-        if connection is not None:
-            last_connection = connection
-            if connection["role"] == "Peripheral":
-                return {"success": True, **connection}
-            try:
-                subprocess.run(
-                    [
-                        "hcitool", "-i", connection["adapter"], "sr",
-                        address, "peripheral",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    timeout=2,
-                    check=False,
-                )
-            except (OSError, subprocess.TimeoutExpired):
-                pass
-            updated = get_connection_roles(adapter_names).get(address)
-            if updated is not None:
-                last_connection = updated
-                if updated["role"] == "Peripheral":
-                    return {"success": True, **updated}
-        if attempt + 1 < attempts:
-            time.sleep(retry_delay)
-    return {"success": False, **(last_connection or {})}
-
-
 def _adapter_names():
     return sorted(
         path.name for path in Path('/sys/class/bluetooth').glob('hci[0-9]*')
@@ -76,51 +43,42 @@ def _adapter_names():
     )
 
 
-def enforce_active_peripheral_roles(controller_manager):
-    """Request Peripheral for active PS Move links that are currently Central."""
-    active_addresses = {
-        str(address).upper() for address in controller_manager.connected_serials()
-    }
-    adapter_names = _adapter_names()
-    roles = get_connection_roles(adapter_names)
-    attempted = []
-    for address in active_addresses:
-        connection = roles.get(address)
-        if connection is None or connection['role'] != 'Central':
-            continue
-        attempted.append(address)
+_ROLE_CHANGE_LOCK = threading.Lock()
+
+
+def set_connection_role(address, role):
+    """Request one explicit role change and verify the actual resulting role."""
+    if not isinstance(address, str) or not re.fullmatch(r'(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}', address):
+        raise ValueError('Invalid controller address.')
+    if role not in ('central', 'peripheral'):
+        raise ValueError('Choose Central or Peripheral.')
+    address = address.upper()
+    if not _ROLE_CHANGE_LOCK.acquire(blocking=False):
+        raise RuntimeError('Another Bluetooth role change is in progress.')
+    try:
+        connection = get_connection_roles(_adapter_names()).get(address)
+        if connection is None:
+            raise RuntimeError('Controller is no longer connected over Bluetooth.')
+        if connection['role'].lower() == role:
+            return dict(connection, success=True)
+        adapter = connection['adapter']
         try:
             subprocess.run(
-                [
-                    'hcitool', '-i', connection['adapter'], 'sr',
-                    address, 'peripheral',
-                ],
-                capture_output=True,
-                text=True,
-                timeout=2,
-                check=False,
+                ['hcitool', '-i', adapter, 'sr', address, role],
+                capture_output=True, text=True, timeout=2, check=True,
             )
-        except (OSError, subprocess.TimeoutExpired):
-            pass
-    return attempted
-
-
-def start_peripheral_role_monitor(controller_manager, interval=1.0):
-    """Continuously repair late or renegotiated PS Move connection roles."""
-    def monitor():
-        while True:
-            try:
-                enforce_active_peripheral_roles(controller_manager)
-            except Exception:
-                # Diagnostics report the live role. A monitoring failure must
-                # never take down the game or controller input path.
-                pass
-            time.sleep(interval)
-
-    thread = threading.Thread(
-        target=monitor,
-        name='PSMove-role-monitor',
-        daemon=True,
-    )
-    thread.start()
-    return thread
+        except (OSError, subprocess.SubprocessError) as error:
+            raise RuntimeError('Bluetooth role change failed. The adapter or controller may not support this switch.') from error
+        # HCI completion can arrive after hcitool exits. Observe, never force
+        # the role repeatedly or assume that a successful command means success.
+        for attempt in range(5):
+            updated = get_connection_roles([adapter]).get(address)
+            if updated is None:
+                raise RuntimeError('Controller disconnected during the role change.')
+            if updated['role'].lower() == role:
+                return dict(updated, success=True)
+            if attempt < 4:
+                time.sleep(0.1)
+        raise RuntimeError('The requested role was not accepted; the controller remains ' + updated['role'] + '.')
+    finally:
+        _ROLE_CHANGE_LOCK.release()

--- a/piparty.py
+++ b/piparty.py
@@ -53,7 +53,6 @@ import logging.config
 import setproctitle
 
 if platform == "linux" or platform == "linux2":
-    import bluetooth_roles
     import dbus
     import jm_dbus
     import pair
@@ -372,10 +371,8 @@ class Menu():
         # All of the moves connected via BT or USB, moves connected via both will appear twice
         self.controller_manager = controller_manager.get_manager()
         self.moves = self.controller_manager.connected_controllers()
-        if platform == "linux" or platform == "linux2":
-            self.bluetooth_role_monitor = bluetooth_roles.start_peripheral_role_monitor(
-                self.controller_manager
-            )
+        # Let BlueZ negotiate roles. Forcing every link to Peripheral can
+        # constrain adapter capacity; the debug page still reports live roles.
 
         # Give the WebUI direct access to the shared controller sequences so
         # live update rates continue advancing while a game owns the menu loop.
@@ -503,22 +500,6 @@ class Menu():
         #If move is not already being tracked
         if move_serial not in self.tracked_moves:
             logger.debug("Pairing BT move: {}".format(move_serial))
-            if platform == "linux" or platform == "linux2":
-                role_result = bluetooth_roles.ensure_peripheral(
-                    move_serial,
-                    list(jm_dbus.get_hci_dict().keys()),
-                )
-                if role_result.get("success"):
-                    logger.info(
-                        "Bluetooth role for %s is Peripheral on %s",
-                        move_serial,
-                        role_result.get("adapter", "unknown adapter"),
-                    )
-                else:
-                    logger.warning(
-                        "Could not switch Bluetooth role for %s to Peripheral",
-                        move_serial,
-                    )
             color = Array('i', [0] * 3)
             # TODO: this probably should be tracked above
             # Individual move run-time parameters, initialize them all to 0

--- a/templates/controller_debug.html
+++ b/templates/controller_debug.html
@@ -19,6 +19,7 @@
 .rate-slow { background-color: #ff8080; }
 .rate-warning { background-color: #ffe680; }
 .rate-good { background-color: #80ff80; }
+button.role-toggle { font-size: 11px; line-height: 1.2; padding: 2px 5px; margin: 3px 0 0; min-width: 0; min-height: 0; width: auto; height: auto; white-space: nowrap; }
 </style>
 {% endblock %}
 
@@ -72,7 +73,13 @@
             <tr data-controller="{{ controller.address }}">
                 <td class="{% if controller.connected %}connected{% else %}disconnected{% endif %}">{{ controller.status }}</td>
                 <td class="controller-rate">Measuring…</td>
-                <td>{{ controller.role }}</td>
+                <td>{{ controller.role }}<br>
+                    <button type="button" class="role-toggle" data-address="{{ controller.address }}"
+                            data-role="{{ 'peripheral' if controller.role == 'Central' else 'central' }}"
+                            {% if not controller.connected or controller.role not in ['Central', 'Peripheral'] %}disabled{% endif %}>
+                        Switch to {{ 'Peripheral' if controller.role == 'Central' else 'Central' }}
+                    </button>
+                </td>
                 <td{% if controller.battery_code is not none %} class="batt{{ controller.battery_code }}"{% endif %}>{{ controller.battery }}</td>
                 <td>{% if controller.active is none %}Unknown{% elif controller.active %}Yes{% else %}No{% endif %}</td>
                 <td>{{ controller.address }}</td>
@@ -112,11 +119,71 @@
         <button type="submit" class="danger-button">Reset Bluetooth Controllers</button>
     </form>
     <p class="diagnostic-note">This stops the current game, clears saved PS Move registrations, and restarts JoustMania. Controllers may need to reconnect or be paired again.</p>
+    <section>
+        <h3>Controller Roles</h3>
+        <button type="button" id="all-peripheral">Try All Peripheral</button>
+        <p class="diagnostic-note">Peripheral mode may improve controller data rates, but it can reduce the number of controllers that can connect at once.
+        This makes a one-time switch attempt; roles are not forced afterward.</p>
+        <p id="all-peripheral-status" role="status"></p>
+    </section>
 </div>
 <script>
 (function () {
     let lastTime = Date.now();
     const controllerLast = {};
+    const rolePending = {};
+    const roleMessages = {};
+    let bulkRolePending = false;
+    async function switchControllerRole(address, role) {
+        rolePending[address] = true;
+        roleMessages[address] = 'Switching…';
+        try {
+            const response = await fetch('/debug/controller-role', {
+                method: 'POST', body: new URLSearchParams({address: address, role: role})
+            });
+            const data = await response.json();
+            if (!response.ok) throw new Error(data.error || 'Role change failed.');
+            roleMessages[address] = 'Switched to ' + data.role + '.';
+            return true;
+        } catch (error) {
+            roleMessages[address] = error.message;
+            return false;
+        } finally {
+            delete rolePending[address];
+        }
+    }
+    document.addEventListener('click', async function (event) {
+        const button = event.target.closest('.role-toggle');
+        if (!button || button.disabled || bulkRolePending) return;
+        button.disabled = true;
+        button.textContent = 'Switching…';
+        document.getElementById('all-peripheral').disabled = true;
+        await switchControllerRole(button.dataset.address, button.dataset.role);
+        document.getElementById('all-peripheral').disabled = Object.keys(rolePending).length > 0;
+    });
+    document.getElementById('all-peripheral').addEventListener('click', async function () {
+        if (bulkRolePending || Object.keys(rolePending).length) return;
+        // Already-Peripheral links need no request. Ignore disconnected/unknown links.
+        const addresses = Array.from(document.querySelectorAll('.role-toggle[data-role="peripheral"]'))
+            .filter(function (button) { return !button.disabled; })
+            .map(function (button) { return button.dataset.address; });
+        const status = document.getElementById('all-peripheral-status');
+        if (!addresses.length) {
+            status.textContent = 'No connected Central-role controllers to switch.';
+            return;
+        }
+        bulkRolePending = true;
+        this.disabled = true;
+        let succeeded = 0;
+        for (let index = 0; index < addresses.length; index++) {
+            status.textContent = 'Trying controller ' + (index + 1) + ' of ' + addresses.length + '…';
+            if (await switchControllerRole(addresses[index], 'peripheral')) succeeded++;
+        }
+        bulkRolePending = false;
+        this.disabled = false;
+        status.textContent = 'Switched ' + succeeded + ' of ' + addresses.length +
+            ' controllers to Peripheral. ' + (addresses.length - succeeded) + ' failed; see each controller’s result.';
+    });
     function cell(row, value, className) {
         const item = document.createElement('td');
         item.textContent = value;
@@ -153,6 +220,24 @@
             }
             cell(row, rate, rateClass);
             cell(row, controller.role);
+            const roleCell = row.lastElementChild;
+            roleCell.appendChild(document.createElement('br'));
+            const roleButton = document.createElement('button');
+            roleButton.type = 'button';
+            roleButton.className = 'role-toggle';
+            roleButton.dataset.address = controller.address;
+            roleButton.dataset.role = controller.role === 'Central' ? 'peripheral' : 'central';
+            roleButton.textContent = rolePending[controller.address] ? 'Switching…' :
+                ('Switch to ' + (controller.role === 'Central' ? 'Peripheral' : 'Central'));
+            roleButton.disabled = bulkRolePending || Boolean(rolePending[controller.address]) || !controller.connected ||
+                !['Central', 'Peripheral'].includes(controller.role);
+            roleCell.appendChild(roleButton);
+            if (roleMessages[controller.address]) {
+                const message = document.createElement('div');
+                message.setAttribute('role', 'status');
+                message.textContent = roleMessages[controller.address];
+                roleCell.appendChild(message);
+            }
             cell(row, controller.battery, controller.battery_code === null ? '' : 'batt' + controller.battery_code);
             cell(row, controller.active === null ? 'Unknown' : (controller.active ? 'Yes' : 'No'));
             cell(row, controller.address);

--- a/templates/controller_debug.html
+++ b/templates/controller_debug.html
@@ -19,7 +19,7 @@
 .rate-slow { background-color: #ff8080; }
 .rate-warning { background-color: #ffe680; }
 .rate-good { background-color: #80ff80; }
-button.role-toggle { font-size: 11px; line-height: 1.2; padding: 2px 5px; margin: 3px 0 0; min-width: 0; min-height: 0; width: auto; height: auto; white-space: nowrap; }
+button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margin: 0; min-width: 0; min-height: 32px; width: auto; height: auto; white-space: nowrap; }
 </style>
 {% endblock %}
 
@@ -56,6 +56,7 @@ button.role-toggle { font-size: 11px; line-height: 1.2; padding: 2px 5px; margin
                 <th>Status</th>
                 <th>Updates/s</th>
                 <th>Role</th>
+                <th>Switch Role</th>
                 <th>Battery</th>
                 <th>Active</th>
                 <th>Controller</th>
@@ -73,7 +74,8 @@ button.role-toggle { font-size: 11px; line-height: 1.2; padding: 2px 5px; margin
             <tr data-controller="{{ controller.address }}">
                 <td class="{% if controller.connected %}connected{% else %}disconnected{% endif %}">{{ controller.status }}</td>
                 <td class="controller-rate">Measuring…</td>
-                <td>{{ controller.role }}<br>
+                <td>{{ controller.role }}</td>
+                <td>
                     <button type="button" class="role-toggle" data-address="{{ controller.address }}"
                             data-role="{{ 'peripheral' if controller.role == 'Central' else 'central' }}"
                             {% if not controller.connected or controller.role not in ['Central', 'Peripheral'] %}disabled{% endif %}>
@@ -93,7 +95,7 @@ button.role-toggle { font-size: 11px; line-height: 1.2; padding: 2px 5px; margin
             </tr>
             {% else %}
             <tr>
-                <td colspan="13">No controllers are assigned to this adapter.</td>
+                <td colspan="14">No controllers are assigned to this adapter.</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -143,7 +145,7 @@ button.role-toggle { font-size: 11px; line-height: 1.2; padding: 2px 5px; margin
             });
             const data = await response.json();
             if (!response.ok) throw new Error(data.error || 'Role change failed.');
-            roleMessages[address] = 'Switched to ' + data.role + '.';
+            delete roleMessages[address];
             return true;
         } catch (error) {
             roleMessages[address] = error.message;
@@ -220,8 +222,8 @@ button.role-toggle { font-size: 11px; line-height: 1.2; padding: 2px 5px; margin
             }
             cell(row, rate, rateClass);
             cell(row, controller.role);
+            cell(row, '');
             const roleCell = row.lastElementChild;
-            roleCell.appendChild(document.createElement('br'));
             const roleButton = document.createElement('button');
             roleButton.type = 'button';
             roleButton.className = 'role-toggle';
@@ -250,7 +252,7 @@ button.role-toggle { font-size: 11px; line-height: 1.2; padding: 2px 5px; margin
             if (body.children.length) return;
             const row = document.createElement('tr');
             const item = document.createElement('td');
-            item.colSpan = 13;
+            item.colSpan = 14;
             item.textContent = body.dataset.forAdapter === 'unknown'
                 ? 'No unassigned controllers.'
                 : 'No controllers are assigned to this adapter.';

--- a/test_bluetooth_roles.py
+++ b/test_bluetooth_roles.py
@@ -1,72 +1,77 @@
+import subprocess
 import unittest
 from unittest import mock
 
 import bluetooth_roles
 
+ADDRESS = 'AA:BB:CC:DD:EE:FF'
+
+
+def connection(role):
+    return {ADDRESS: {'adapter': 'hci1', 'handle': 3, 'role': role}}
+
 
 class BluetoothRolesTest(unittest.TestCase):
-    @mock.patch.object(bluetooth_roles.subprocess, "run")
+    @mock.patch.object(bluetooth_roles.subprocess, 'run')
     def test_connection_roles_are_scoped_to_adapter(self, run):
-        run.return_value.stdout = (
-            "Connections:\n"
-            "\t> ACL 00:06:F7:8F:FA:3C handle 2 state 1 lm CENTRAL \n"
-        )
-        roles = bluetooth_roles.get_connection_roles(["hci1"])
-        self.assertEqual(roles["00:06:F7:8F:FA:3C"], {
-            "adapter": "hci1", "handle": 2, "role": "Central",
-        })
+        run.return_value.stdout = 'Connections:\n\t> ACL AA:BB:CC:DD:EE:FF handle 3 state 1 lm CENTRAL\n'
+        self.assertEqual(bluetooth_roles.get_connection_roles(['hci1']), connection('Central'))
 
-    @mock.patch.object(bluetooth_roles, "get_connection_roles")
-    @mock.patch.object(bluetooth_roles.subprocess, "run")
-    def test_central_connection_is_switched_and_verified(self, run, roles):
-        roles.side_effect = [
-            {"AA:BB:CC:DD:EE:FF": {"adapter": "hci1", "handle": 3, "role": "Central"}},
-            {"AA:BB:CC:DD:EE:FF": {"adapter": "hci1", "handle": 3, "role": "Peripheral"}},
-        ]
-        result = bluetooth_roles.ensure_peripheral(
-            "aa:bb:cc:dd:ee:ff", ["hci0", "hci1"], retry_delay=0
-        )
-        self.assertTrue(result["success"])
-        run.assert_called_once_with(
-            ["hcitool", "-i", "hci1", "sr", "AA:BB:CC:DD:EE:FF", "peripheral"],
-            capture_output=True, text=True, timeout=2, check=False,
-        )
+    @mock.patch.object(bluetooth_roles, '_adapter_names', return_value=['hci0', 'hci1'])
+    @mock.patch.object(bluetooth_roles, 'get_connection_roles')
+    @mock.patch.object(bluetooth_roles.subprocess, 'run')
+    def test_each_direction_uses_actual_adapter_and_verifies(self, run, roles, names):
+        for before, target in [('Central', 'Peripheral'), ('Peripheral', 'Central')]:
+            with self.subTest(target=target):
+                roles.side_effect = [connection(before), connection(target)]
+                result = bluetooth_roles.set_connection_role(ADDRESS.lower(), target.lower())
+                self.assertEqual(result['role'], target)
+                run.assert_called_with(['hcitool', '-i', 'hci1', 'sr', ADDRESS, target.lower()],
+                                       capture_output=True, text=True, timeout=2, check=True)
+                roles.assert_called_with(['hci1'])
 
-    @mock.patch.object(bluetooth_roles, "get_connection_roles")
-    @mock.patch.object(bluetooth_roles.subprocess, "run")
-    def test_peripheral_connection_is_left_alone(self, run, roles):
-        roles.return_value = {
-            "AA:BB:CC:DD:EE:FF": {
-                "adapter": "hci0", "handle": 1, "role": "Peripheral",
-            }
-        }
-        result = bluetooth_roles.ensure_peripheral(
-            "AA:BB:CC:DD:EE:FF", ["hci0"]
-        )
-        self.assertTrue(result["success"])
+    @mock.patch.object(bluetooth_roles, 'get_connection_roles', return_value=connection('Central'))
+    @mock.patch.object(bluetooth_roles.subprocess, 'run')
+    def test_already_requested_role_is_noop(self, run, roles):
+        self.assertTrue(bluetooth_roles.set_connection_role(ADDRESS, 'central')['success'])
         run.assert_not_called()
 
-    @mock.patch.object(bluetooth_roles, "_adapter_names", return_value=["hci0"])
-    @mock.patch.object(bluetooth_roles, "get_connection_roles")
-    @mock.patch.object(bluetooth_roles.subprocess, "run")
-    def test_monitor_repairs_only_active_central_links(self, run, roles, _names):
-        manager = mock.Mock()
-        manager.connected_serials.return_value = ["AA:BB:CC:DD:EE:FF"]
-        roles.return_value = {
-            "AA:BB:CC:DD:EE:FF": {
-                "adapter": "hci0", "handle": 1, "role": "Central",
-            },
-            "11:22:33:44:55:66": {
-                "adapter": "hci0", "handle": 2, "role": "Central",
-            },
-        }
-        attempted = bluetooth_roles.enforce_active_peripheral_roles(manager)
-        self.assertEqual(attempted, ["AA:BB:CC:DD:EE:FF"])
-        run.assert_called_once_with(
-            ["hcitool", "-i", "hci0", "sr", "AA:BB:CC:DD:EE:FF", "peripheral"],
-            capture_output=True, text=True, timeout=2, check=False,
-        )
+    @mock.patch.object(bluetooth_roles, 'get_connection_roles', return_value={})
+    @mock.patch.object(bluetooth_roles.subprocess, 'run')
+    def test_disconnected_controller_does_not_run_switch(self, run, roles):
+        with self.assertRaisesRegex(RuntimeError, 'no longer connected'):
+            bluetooth_roles.set_connection_role(ADDRESS, 'central')
+        run.assert_not_called()
+
+    @mock.patch.object(bluetooth_roles.time, 'sleep')
+    @mock.patch.object(bluetooth_roles, 'get_connection_roles', return_value=connection('Central'))
+    @mock.patch.object(bluetooth_roles.subprocess, 'run')
+    def test_successful_command_does_not_hide_rejected_role(self, run, roles, sleep):
+        with self.assertRaisesRegex(RuntimeError, 'not accepted'):
+            bluetooth_roles.set_connection_role(ADDRESS, 'peripheral')
+        self.assertEqual(run.call_count, 1)
+
+    @mock.patch.object(bluetooth_roles, 'get_connection_roles')
+    @mock.patch.object(bluetooth_roles.subprocess, 'run')
+    def test_disconnect_during_switch_is_reported(self, run, roles):
+        roles.side_effect = [connection('Central'), {}]
+        with self.assertRaisesRegex(RuntimeError, 'disconnected during'):
+            bluetooth_roles.set_connection_role(ADDRESS, 'peripheral')
+
+    @mock.patch.object(bluetooth_roles, 'get_connection_roles', return_value=connection('Central'))
+    @mock.patch.object(bluetooth_roles.subprocess, 'run', side_effect=subprocess.TimeoutExpired('hcitool', 2))
+    def test_timeout_releases_lock(self, run, roles):
+        with self.assertRaisesRegex(RuntimeError, 'role change failed'):
+            bluetooth_roles.set_connection_role(ADDRESS, 'peripheral')
+        self.assertFalse(bluetooth_roles._ROLE_CHANGE_LOCK.locked())
+
+    @mock.patch.object(bluetooth_roles.subprocess, 'run')
+    def test_invalid_input_never_reaches_hardware(self, run):
+        for address, role in [('--help', 'central'), (ADDRESS, 'invalid')]:
+            with self.assertRaises(ValueError):
+                bluetooth_roles.set_connection_role(address, role)
+        run.assert_not_called()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/test_controller_role_ui.js
+++ b/test_controller_role_ui.js
@@ -1,0 +1,51 @@
+// Run with: node test_controller_role_ui.js
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const script = fs.readFileSync('templates/controller_debug.html', 'utf8').match(/<script>([\s\S]*?)<\/script>/)[1];
+const elements = {};
+const handlers = {};
+function element(id) {
+    return elements[id] ||= {disabled: false, textContent: '', addEventListener(type, fn) {this[type] = fn;}};
+}
+const targets = [
+    {dataset: {address: 'AA:BB:CC:DD:EE:01', role: 'peripheral'}, disabled: false},
+    {dataset: {address: 'AA:BB:CC:DD:EE:02', role: 'peripheral'}, disabled: false},
+    {dataset: {address: 'AA:BB:CC:DD:EE:03', role: 'peripheral'}, disabled: true}
+];
+const requests = [];
+let active = 0, maximumActive = 0;
+const context = {
+    document: {
+        getElementById: element,
+        addEventListener(type, fn) {handlers[type] = fn;},
+        querySelectorAll() {return targets;}
+    },
+    window: {setInterval() {}},
+    URLSearchParams,
+    async fetch(url, options) {
+        active++;
+        maximumActive = Math.max(maximumActive, active);
+        const address = options.body.get('address');
+        requests.push({url, address, role: options.body.get('role')});
+        await new Promise(resolve => setImmediate(resolve));
+        active--;
+        const ok = !address.endsWith('02');
+        return {ok, async json() {return ok ? {role: 'Peripheral'} : {error: 'Switch rejected'};}};
+    }
+};
+vm.runInNewContext(script, context);
+(async () => {
+    await element('all-peripheral').click();
+    assert.equal(requests.length, 2);
+    assert.equal(maximumActive, 1);
+    assert(requests.every(r => r.url === '/debug/controller-role' && r.role === 'peripheral'));
+    assert.match(element('all-peripheral-status').textContent, /Switched 1 of 2/);
+    assert.match(element('all-peripheral-status').textContent, /1 failed/);
+    assert.equal(element('all-peripheral').disabled, false);
+    requests.length = 0;
+    const button = {dataset: {address: 'AA:BB:CC:DD:EE:01', role: 'central'}, disabled: false};
+    await handlers.click({target: {closest() {return button;}}});
+    assert.equal(requests[0].role, 'central');
+    console.log('Controller role UI tests passed');
+})().catch(error => {console.error(error); process.exitCode = 1;});

--- a/test_controller_roles_web.py
+++ b/test_controller_roles_web.py
@@ -1,0 +1,66 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import webui
+
+ADDRESS = 'AA:BB:CC:DD:EE:FF'
+
+
+class ControllerRolesWebTest(unittest.TestCase):
+    def setUp(self):
+        self.ui = webui.WebUI(ns=SimpleNamespace(status={}, battery_status={}))
+        self.client = self.ui.app.test_client()
+        self.controllers = mock.patch.object(self.ui, '_controller_debug_data', return_value=[
+            {'address': ADDRESS, 'connected': True}
+        ])
+        self.controllers.start()
+        self.addCleanup(self.controllers.stop)
+
+    @mock.patch.object(webui.bluetooth_roles, 'set_connection_role')
+    def test_explicit_role_request_is_verified(self, switch):
+        switch.return_value = {'role': 'Central', 'adapter': 'hci0', 'success': True}
+        response = self.client.post('/debug/controller-role', data={'address': ADDRESS.lower(), 'role': 'central'})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['role'], 'Central')
+        switch.assert_called_once_with(ADDRESS, 'central')
+        self.assertEqual(self.client.get('/debug/controller-role').status_code, 405)
+
+    @mock.patch.object(webui.bluetooth_roles, 'set_connection_role')
+    def test_disconnected_or_unrecognized_controller_cannot_be_switched(self, switch):
+        self.ui._controller_debug_data.return_value[0]['connected'] = False
+        response = self.client.post('/debug/controller-role', data={'address': ADDRESS, 'role': 'peripheral'})
+        self.assertEqual(response.status_code, 409)
+        switch.assert_not_called()
+
+    @mock.patch.object(webui.bluetooth_roles, 'set_connection_role')
+    def test_invalid_role_does_not_reach_hardware(self, switch):
+        response = self.client.post('/debug/controller-role', data={'address': ADDRESS, 'role': 'toggle'})
+        self.assertEqual(response.status_code, 400)
+        switch.assert_not_called()
+
+    @mock.patch.object(webui.bluetooth_roles, 'set_connection_role', side_effect=RuntimeError('Switch rejected'))
+    def test_failure_is_reported_to_browser(self, switch):
+        response = self.client.post('/debug/controller-role', data={'address': ADDRESS, 'role': 'peripheral'})
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json['error'], 'Switch rejected')
+
+    @mock.patch.object(webui, 'bluetooth_roles', None)
+    def test_unsupported_platform(self):
+        self.assertEqual(self.client.post('/debug/controller-role').status_code, 501)
+
+    @mock.patch.object(webui.bluetooth_diagnostics, 'get_adapters', return_value=[{'name': 'hci0', 'rx_errors': 0, 'tx_errors': 0}])
+    def test_debug_page_renders_manual_and_bulk_controls(self, adapters):
+        self.ui._controller_debug_data.return_value = [{
+            'address': ADDRESS, 'adapter': 'hci0', 'connected': True,
+            'role': 'Central', 'battery_code': None,
+        }]
+        response = self.client.get('/debug')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Switch to Peripheral', response.data)
+        self.assertIn(b'Try All Peripheral', response.data)
+        self.assertIn(b'reduce the number of controllers', response.data)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_controller_roles_web.py
+++ b/test_controller_roles_web.py
@@ -58,6 +58,7 @@ class ControllerRolesWebTest(unittest.TestCase):
         response = self.client.get('/debug')
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'Switch to Peripheral', response.data)
+        self.assertIn(b'<th>Switch Role</th>', response.data)
         self.assertIn(b'Try All Peripheral', response.data)
         self.assertIn(b'reduce the number of controllers', response.data)
 

--- a/webui.py
+++ b/webui.py
@@ -109,6 +109,7 @@ class WebUI():
         self.app.add_url_rule('/debug','debug',self.controller_debug)
         self.app.add_url_rule('/debug/controllers','controller_debug_legacy',self.controller_debug_legacy)
         self.app.add_url_rule('/debug/data','debug_data',self.debug_data)
+        self.app.add_url_rule('/debug/controller-role', 'controller_role', self.change_controller_role, methods=['POST'])
         self.app.add_url_rule(
             '/debug/reset-bluetooth',
             'reset_bluetooth',
@@ -180,6 +181,24 @@ class WebUI():
             "adapters": bluetooth_diagnostics.get_adapters(),
             "controllers": self._controller_debug_data(),
         }
+
+    def change_controller_role(self):
+        if bluetooth_roles is None:
+            return {'error': 'Role switching is only available on Linux.'}, 501
+        address = request.form.get('address', '').upper()
+        role = request.form.get('role', '')
+        if role not in ('central', 'peripheral'):
+            return {'error': 'Choose Central or Peripheral.'}, 400
+        controller = next((c for c in self._controller_debug_data()
+                           if c['address'].upper() == address and c['connected']), None)
+        if controller is None:
+            return {'error': 'Controller is not connected over Bluetooth.'}, 409
+        try:
+            return bluetooth_roles.set_connection_role(address, role)
+        except ValueError as error:
+            return {'error': str(error)}, 400
+        except RuntimeError as error:
+            return {'error': str(error)}, 409
 
     def reset_bluetooth(self):
         """Launch the existing reset workflow after this response is sent.


### PR DESCRIPTION
Forcing every Bluetooth link to Peripheral limited the observed three-adapter setup to two connections per adapter. After removing enforcement and switching one adapter's links to Central, it accepted four controllers and the total rose from six to eight.

Remove both automatic role-switch paths: the connection-time request and the one-second background enforcement loop. Add per-controller Central/Peripheral buttons in a Switch Role column beside the current role in System Debug, plus a “Try All Peripheral” button that processes connected Central-role controllers sequentially. Show the actual role, verify each switch, and report rejected switches or disconnects without adding a success message to each row. Explain that Peripheral can improve update rates while reducing connection capacity.

Update the README with these controls, observed 1 GB Pi memory figures and their limitations, and the 2 GB Pi. The web-interface documentation also describes the hotspot controls in #378.

Validation:
- 14 focused Python tests and the JavaScript UI test pass on this standalone branch, covering role verification, both directions, invalid/disconnected targets, timeouts, rendering, sequential bulk requests, and partial failure reporting.
- 32 Python tests and the UI test pass in the local combined development checkout.
- Live HCI trace confirms Central role changes and successful third/fourth controller connections on hci0.
- Local JoustMania restarted for user testing. No bulk Peripheral switch was triggered automatically.

Based on master, without the implementation changes from #377 or #378.
