### PR TITLE
Show report-gap timing and connection quality in System Debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,3 +333,13 @@ If you love this game you can support its development by helping out with my pat
 https://www.patreon.com/adangert
 
 We also have some great [contributors](CONTRIBUTORS.md) if you would you like to help out with development, or find any bug fixes we would be happy to test them out and incorperate them into the repo!
+
+The System Debug controller table also shows application report gaps over a rolling
+10-second window: p95 and the longest completed gap.
+Provisional p95 colors are green ≤22 ms, yellow ≤30 ms, red >30 ms;
+longest-gap colors are green ≤30 ms, yellow ≤50 ms, red >50 ms.
+These thresholds reflect initial controller tests, not Bluetooth standards.
+Hover over p95 for p99 and counts of pauses over 50/100 ms. These measure delivery
+to JoustMania, not over-air timing or motion-to-game latency. History resets on
+reconnection. Timing uses Python's standard library; no additional setup packages
+or packet-capture tools are required.

--- a/controller_manager.py
+++ b/controller_manager.py
@@ -16,6 +16,7 @@ import time
 
 import proton_psmove
 import runtime_platform
+from report_timing import ReportTiming
 
 
 MAX_CONTROLLERS = 64
@@ -47,6 +48,7 @@ class ControllerManager:
         self.usb = multiprocessing.RawArray(ctypes.c_ubyte, MAX_CONTROLLERS)
         self.bluetooth = multiprocessing.RawArray(ctypes.c_ubyte, MAX_CONTROLLERS)
         self.state_sequence = multiprocessing.RawArray(ctypes.c_ulonglong, MAX_CONTROLLERS)
+        self.report_timing = ReportTiming(MAX_CONTROLLERS)
         self.buttons = multiprocessing.RawArray(ctypes.c_uint, MAX_CONTROLLERS)
         self.pressed = multiprocessing.RawArray(ctypes.c_uint, MAX_CONTROLLERS)
         self.released = multiprocessing.RawArray(ctypes.c_uint, MAX_CONTROLLERS)
@@ -211,6 +213,7 @@ def _api_process_main(manager):
             discovered and provides its ctypes-backed controller wrapper.
             """
             controller_index = controller_index_for(psmove_controller.serial)
+            manager.report_timing.reset(controller_index)
             manager.active[controller_index] = 1
             manager.usb[controller_index] = int(psmove_controller.usb)
             manager.bluetooth[controller_index] = int(psmove_controller.bluetooth)
@@ -224,6 +227,7 @@ def _api_process_main(manager):
             fields after this callback returns.
             """
             controller_index = controller_index_for(psmove_controller.serial)
+            manager.report_timing.record(controller_index)
             manager.active[controller_index] = 1
             manager.usb[controller_index] = int(psmove_controller.usb)
             manager.bluetooth[controller_index] = int(psmove_controller.bluetooth)
@@ -264,6 +268,7 @@ def _api_process_main(manager):
             controller_index = local_controller_indices.get(psmove_controller.serial)
             if controller_index is not None:
                 manager.active[controller_index] = 0
+                manager.report_timing.reset(controller_index)
                 manager.usb[controller_index] = 0
                 manager.bluetooth[controller_index] = 0
 

--- a/report_timing.py
+++ b/report_timing.py
@@ -1,0 +1,55 @@
+"""Bounded, shared measurements of application report arrival timing."""
+import ctypes
+import math
+import multiprocessing
+import time
+
+
+class ReportTiming:
+    def __init__(self, controllers, capacity=2048, window_s=10.0):
+        self.capacity = capacity
+        self.window_s = window_s
+        self.timestamps = multiprocessing.RawArray(ctypes.c_double, controllers * capacity)
+        self.counts = multiprocessing.RawArray(ctypes.c_ulonglong, controllers)
+        self.locks = [multiprocessing.Lock() for _ in range(controllers)]
+
+    def reset(self, index):
+        with self.locks[index]:
+            self.counts[index] = 0
+
+    def record(self, index, now=None):
+        now = time.monotonic() if now is None else now
+        with self.locks[index]:
+            count = self.counts[index]
+            self.timestamps[index * self.capacity + count % self.capacity] = now
+            self.counts[index] = count + 1
+
+    def snapshot(self, index, now=None):
+        with self.locks[index]:
+            count = self.counts[index]
+            size = min(count, self.capacity)
+            start = index * self.capacity
+            values = list(self.timestamps[start:start + size])
+        # Take 'now' after copying, so a concurrent new report cannot appear
+        # to have arrived in the future relative to the snapshot clock.
+        now = time.monotonic() if now is None else now
+        if count > self.capacity:
+            offset = count % self.capacity
+            values = values[offset:] + values[:offset]
+        cutoff = now - self.window_s
+        gaps = sorted((end - begin) * 1000 for begin, end in zip(values, values[1:])
+                      if end >= cutoff)
+        def percentile(fraction):
+            return round(gaps[math.ceil(fraction * len(gaps)) - 1], 2) if gaps else None
+        return {
+            'source': 'application',
+            'window_s': self.window_s,
+            'sample_count': len(gaps),
+            'p95_ms': percentile(0.95),
+            'p99_ms': percentile(0.99),
+            'max_ms': round(gaps[-1], 2) if gaps else None,
+            'last_report_age_ms': round(max(0, now - values[-1]) * 1000, 2) if values else None,
+            'gaps_over_50ms': sum(gap > 50 for gap in gaps),
+            'gaps_over_100ms': sum(gap > 100 for gap in gaps),
+            'sample_limited': count > self.capacity and values[0] >= cutoff,
+        }

--- a/templates/controller_debug.html
+++ b/templates/controller_debug.html
@@ -26,9 +26,15 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
 {% block body %}
 <div class="info_box">
     <h2>Bluetooth Adapters</h2>
+    <p class="diagnostic-note">Report gaps measure time between updates received by JoustMania over the last 10 seconds.
+    The p95 value means 95% of completed gaps were that short or shorter; lower means fewer long pauses.
+    Longest gap shows the worst completed pause in that window.
+    Provisional ratings from our controller tests: p95 green ≤22 ms, yellow ≤30 ms, red &gt;30 ms;
+    longest gap green ≤30 ms, yellow ≤50 ms, red &gt;50 ms.
+    These measure application delivery timing, not motion-to-game latency. Hover over p95 for more detail.</p>
     <p class="diagnostic-note">Live rates are HCI packets handled by each adapter. With controllers connected,
-    a much lower RX ACL rate identifies the slow path directly. With no controllers, identity and hardware error
-    checks still work, but an idle adapter cannot prove radio throughput; “No reported errors” is not a speed test.</p>
+    packet rates vary with controller type and traffic. Assessment summarizes connected controllers using their p95 report gaps.
+    Mixed results are listed separately; this is a connection assessment, not an adapter speed rating.</p>
     <div id="bluetooth-adapter-body">
     {% for adapter in adapters %}
     <section class="adapter-section" data-adapter-section="{{ adapter.name }}">
@@ -45,7 +51,7 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
                 <td class="adapter-tx-power">{% if adapter.inquiry_tx_power_dbm is not none %}{{ adapter.inquiry_tx_power_dbm }} dBm{% else %}Unavailable{% endif %}</td>
                 <td class="adapter-acl-mtu">{{ adapter.acl_mtu }}</td><td class="connections">{{ adapter.connections }}</td>
                 <td class="rx-rate">Measuring…</td><td class="tx-rate">Measuring…</td>
-                <td class="errors">{{ adapter.rx_errors + adapter.tx_errors }}</td><td class="health">{{ adapter.health }}</td>
+                <td class="errors">{{ adapter.rx_errors + adapter.tx_errors }}</td><td class="health">{{ 'Measuring connections…' if adapter.connections else adapter.health }}</td>
             </tr>
         </tbody>
         </table>
@@ -54,7 +60,7 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
         <thead>
             <tr>
                 <th>Status</th>
-                <th>Updates/s</th>
+                <th>Updates/s</th><th>Report gap p95</th><th>Longest gap (10 s)</th>
                 <th>Role</th>
                 <th>Switch Role</th>
                 <th>Battery</th>
@@ -74,6 +80,7 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
             <tr data-controller="{{ controller.address }}">
                 <td class="{% if controller.connected %}connected{% else %}disconnected{% endif %}">{{ controller.status }}</td>
                 <td class="controller-rate">Measuring…</td>
+                <td>Measuring…</td><td>Measuring…</td>
                 <td>{{ controller.role }}</td>
                 <td>
                     <button type="button" class="role-toggle" data-address="{{ controller.address }}"
@@ -95,7 +102,7 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
             </tr>
             {% else %}
             <tr>
-                <td colspan="14">No controllers are assigned to this adapter.</td>
+                <td colspan="16">No controllers are assigned to this adapter.</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -230,6 +237,26 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
         if (className) item.className = className;
         row.appendChild(item);
     }
+    function connectionAssessment(adapter, controllers) {
+        const connected = controllers.filter(controller => controller.connected && controller.adapter === adapter.name);
+        if (!connected.length) return adapter.connections ? 'Connection timing unavailable' : 'No active connections';
+        const counts = {good: 0, borderline: 0, slow: 0, measuring: 0};
+        connected.forEach(controller => {
+            const gap = controller.report_gap && controller.report_gap.p95_ms;
+            if (!Number.isFinite(gap)) counts.measuring++;
+            else if (gap <= 22) counts.good++;
+            else if (gap <= 30) counts.borderline++;
+            else counts.slow++;
+        });
+        const groups = Object.entries(counts).filter(([, count]) => count > 0);
+        if (groups.length === 1) {
+            const [rating, count] = groups[0];
+            if (rating === 'measuring') return 'Measuring connections…';
+            return rating[0].toUpperCase() + rating.slice(1) +
+                (count === 1 ? ' connection' : ' connections (' + count + ')');
+        }
+        return 'Mixed: ' + groups.map(([rating, count]) => count + ' ' + rating).join(', ');
+    }
     function renderControllers(controllers, seconds) {
         const bodies = Array.from(document.querySelectorAll('.controller-status-body'));
         bodies.forEach(function (body) { body.textContent = ''; });
@@ -259,6 +286,23 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
                 else rateClass += ' rate-good';
             }
             cell(row, rate, rateClass);
+            const gaps = controller.report_gap;
+            function gapValue(key, suffix) {
+                if (!controller.connected) return '—';
+                if (!gaps) return 'Unavailable';
+                return Number.isFinite(gaps[key]) ? gaps[key].toFixed(1) + suffix : 'Measuring…';
+            }
+            function gapClass(key, good, warning) {
+                if (!controller.connected || !gaps || !Number.isFinite(gaps[key])) return 'nowrap';
+                return 'nowrap ' + (gaps[key] <= good ? 'rate-good' :
+                    (gaps[key] <= warning ? 'rate-warning' : 'rate-slow'));
+            }
+            cell(row, gapValue('p95_ms', ' ms'), gapClass('p95_ms', 22, 30));
+            if (gaps) row.lastElementChild.title = 'Last ' + gaps.window_s + ' seconds; ' +
+                gaps.sample_count + ' completed gaps. p99: ' + gapValue('p99_ms', ' ms') +
+                '; pauses over 50 ms: ' + gaps.gaps_over_50ms + '; over 100 ms: ' + gaps.gaps_over_100ms +
+                (gaps.sample_limited ? '. Limited to most recent samples.' : '');
+            cell(row, gapValue('max_ms', ' ms'), gapClass('max_ms', 30, 50));
             cell(row, controller.role);
             cell(row, '');
             const roleCell = row.lastElementChild;
@@ -290,7 +334,7 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
             if (body.children.length) return;
             const row = document.createElement('tr');
             const item = document.createElement('td');
-            item.colSpan = 14;
+            item.colSpan = 16;
             item.textContent = body.dataset.forAdapter === 'unknown'
                 ? 'No unassigned controllers.'
                 : 'No controllers are assigned to this adapter.';
@@ -336,11 +380,7 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
                 row.querySelector('.tx-rate').textContent = adapter.connections ? txRate.toFixed(1) : '—';
                 row.querySelector('.connections').textContent = adapter.connections;
                 row.querySelector('.errors').textContent = adapter.rx_errors + adapter.tx_errors;
-                let health = adapter.connections ? adapter.health : 'Idle — no controller links';
-                if (adapter.connections && rxRate < 80) health = 'SLOW controller traffic';
-                else if (adapter.connections && rxRate >= 85) health = 'Healthy controller traffic';
-                else if (adapter.connections) health = 'Borderline controller traffic';
-                row.querySelector('.health').textContent = health;
+                row.querySelector('.health').textContent = connectionAssessment(adapter, data.controllers);
                 row.dataset.rx = adapter.rx_acl; row.dataset.tx = adapter.tx_acl;
             });
             renderControllers(data.controllers, seconds);

--- a/test_controller_role_ui.js
+++ b/test_controller_role_ui.js
@@ -34,7 +34,7 @@ const context = {
         return {ok, async json() {return ok ? {role: 'Peripheral'} : {error: 'Switch rejected'};}};
     }
 };
-vm.runInNewContext(script, context);
+vm.runInNewContext(script.replace('}());', 'globalThis.renderControllers = renderControllers; globalThis.connectionAssessment = connectionAssessment;}());'), context);
 (async () => {
     await element('all-peripheral').click();
     assert.equal(requests.length, 2);
@@ -47,5 +47,47 @@ vm.runInNewContext(script, context);
     const button = {dataset: {address: 'AA:BB:CC:DD:EE:01', role: 'central'}, disabled: false};
     await handlers.click({target: {closest() {return button;}}});
     assert.equal(requests[0].role, 'central');
-    console.log('Controller role UI tests passed');
+    function node() {
+        return {children: [], dataset: {}, style: {},
+            appendChild(child) {this.children.push(child); this.lastElementChild = child;},
+            setAttribute() {},
+            set textContent(value) {this.text = value; this.children = [];},
+            get textContent() {return this.text || '';}};
+    }
+    const body = node(); body.dataset.forAdapter = 'hci0';
+    const unknown = node(); unknown.dataset.forAdapter = 'unknown';
+    context.document.createElement = node;
+    context.document.querySelectorAll = () => [body, unknown];
+    context.document.querySelector = selector => selector.includes('unknown') ? unknown : body;
+    element('unassigned-controller-section').style = {};
+    const controller = {address: 'AA', adapter: 'hci0', connected: true, role: 'Central',
+        update_count: 10, report_gap: {p95_ms: 36, p99_ms: 40, max_ms: 80,
+            last_report_age_ms: 500, sample_count: 600, window_s: 10,
+            gaps_over_50ms: 2, gaps_over_100ms: 0}};
+    context.renderControllers([controller], 1);
+    assert.equal(body.children[0].children[2].textContent, '36.0 ms');
+    assert.equal(body.children[0].children[3].textContent, '80.0 ms');
+    assert.equal(body.children[0].children[4].textContent, 'Central');
+    assert.equal(body.children[0].children[2].className, 'nowrap rate-slow');
+    assert.equal(body.children[0].children[3].className, 'nowrap rate-slow');
+    for (const [p95, max, color] of [[22, 30, 'rate-good'], [24, 40, 'rate-warning'], [30, 50, 'rate-warning'], [31, 51, 'rate-slow']]) {
+        controller.report_gap.p95_ms = p95; controller.report_gap.max_ms = max;
+        context.renderControllers([controller], 1);
+        assert.equal(body.children[0].children[2].className, 'nowrap ' + color);
+        assert.equal(body.children[0].children[3].className, 'nowrap ' + color);
+    }
+    controller.connected = false;
+    context.renderControllers([controller], 1);
+    assert.equal(body.children[0].children[2].textContent, '—');
+    assert.equal(body.children[0].children[2].className, 'nowrap');
+    controller.connected = true; controller.report_gap = null;
+    context.renderControllers([controller], 1);
+    assert.equal(body.children[0].children[2].textContent, 'Unavailable');
+    const adapter = {name: 'hci0', connections: 2};
+    const link = p95 => ({adapter: 'hci0', connected: true, report_gap: {p95_ms: p95}});
+    assert.equal(context.connectionAssessment(adapter, [link(20), link(36)]), 'Mixed: 1 good, 1 slow');
+    assert.equal(context.connectionAssessment(adapter, [link(36), link(40)]), 'Slow connections (2)');
+    assert.equal(context.connectionAssessment(adapter, [link(24)]), 'Borderline connection');
+    assert.equal(context.connectionAssessment(adapter, [link(null)]), 'Measuring connections…');
+    console.log('Controller role, report gap and assessment UI tests passed');
 })().catch(error => {console.error(error); process.exitCode = 1;});

--- a/test_report_timing.py
+++ b/test_report_timing.py
@@ -1,0 +1,57 @@
+import multiprocessing
+import unittest
+from report_timing import ReportTiming
+
+
+def publish_in_child(timing):
+    timing.record(0, 1.0)
+    timing.record(0, 1.020)
+
+
+class ReportTimingTest(unittest.TestCase):
+    def test_equal_average_rates_can_have_different_gaps(self):
+        regular, bursty = ReportTiming(1), ReportTiming(1)
+        for i in range(101):
+            regular.record(0, i * .01)
+            bursty.record(0, (i // 2) * .02)
+        self.assertEqual(regular.snapshot(0, 1)['p95_ms'], 10)
+        self.assertEqual(bursty.snapshot(0, 1)['p95_ms'], 20)
+
+    def test_rolling_window_and_current_stall(self):
+        timing = ReportTiming(1)
+        for t in [0, .2, 20, 20.01]:
+            timing.record(0, t)
+        data = timing.snapshot(0, 20.01)
+        self.assertEqual(data['sample_count'], 2)
+        self.assertEqual(data['max_ms'], 19800)
+        self.assertEqual(data['gaps_over_100ms'], 1)
+        stalled = timing.snapshot(0, 31)
+        self.assertIsNone(stalled['p95_ms'])
+        self.assertEqual(stalled['last_report_age_ms'], 10990)
+
+    def test_ring_wrap_and_reconnect_do_not_mix_sessions(self):
+        timing = ReportTiming(1, capacity=4)
+        for t in [0, 1, 2, 3, 4, 5]:
+            timing.record(0, t)
+        data = timing.snapshot(0, 5)
+        self.assertEqual(data['sample_count'], 3)
+        self.assertEqual(data['max_ms'], 1000)
+        self.assertTrue(data['sample_limited'])
+        timing.reset(0)
+        self.assertIsNone(timing.snapshot(0, 10)['last_report_age_ms'])
+        timing.record(0, 20)
+        self.assertIsNone(timing.snapshot(0, 20)['p95_ms'])
+        timing.record(0, 20.01)
+        self.assertEqual(timing.snapshot(0, 20.01)['p95_ms'], 10)
+
+    def test_reader_in_another_process_sees_timing(self):
+        timing = ReportTiming(1)
+        process = multiprocessing.Process(target=publish_in_child, args=(timing,))
+        process.start()
+        process.join(timeout=5)
+        self.assertEqual(process.exitcode, 0)
+        self.assertEqual(timing.snapshot(0, 1.02)['p95_ms'], 20)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/webui.py
+++ b/webui.py
@@ -281,7 +281,13 @@ class WebUI():
                 getattr(self.ns, 'controller_update_counts', {})
             ).items()
         }
+        report_gaps = {}
         if self.controller_manager is not None:
+            report_gaps = {
+                str(self.controller_manager.index_to_serial[index]).upper():
+                    self.controller_manager.report_timing.snapshot(index)
+                for index in self.controller_manager.active_controller_indices()
+            }
             update_counts = {
                 str(self.controller_manager.index_to_serial[index]).upper(): int(
                     self.controller_manager.state_sequence[index] // 2
@@ -340,6 +346,7 @@ class WebUI():
                 None if address not in out_moves else out_moves[address] == 0
             )
             controller['update_count'] = update_counts.get(address)
+            controller['report_gap'] = report_gaps.get(address) if controller['connected'] else None
 
         if bluetooth_roles is not None:
             try:


### PR DESCRIPTION
Average controller update rates can hide bursts and long pauses. System Debug now shows each controller’s p95 report gap and longest gap over a rolling 10-second window, with provisional green/yellow/red thresholds. The adapter assessment summarizes individual connection timing, including mixed results, instead of judging controller traffic from average ACL packet rates.

Timing is collected at the existing PSMoveAPI callback using bounded shared memory, resets on reconnection, and includes p99 and pause counts in the tooltip. These metrics describe application delivery timing, not motion-to-game latency. No additional runtime dependencies or setup.sh changes are needed.

Validation:
- 16 Python tests passed for report timing, shared controller state, and debug routes.
- JavaScript UI tests passed for colors, missing/disconnected data, mixed assessments, and existing role controls.
- Verified the live debug page and metrics with connected controllers on the Pi.

Thresholds are provisional and documented in the UI. This draft contains the debug feature and its documentation/tests; adapter test reports and captures remain local.
