### PR TITLE
Prevent disconnected controllers from blocking game startup

### DIFF
--- a/jm_dbus.py
+++ b/jm_dbus.py
@@ -216,3 +216,18 @@ def get_node_interfaces(proxy):
     """List interface names exposed by a DBus node"""
     tree = _introspect_tree(proxy)
     return [child.attrib['name'] for child in tree if child.tag == 'interface']
+
+
+def get_connected_device_addresses():
+    """Return current BlueZ links; propagate failure instead of reporting none."""
+    bus = ensure_process_bus()
+    if not bus.name_has_owner(ORG_BLUEZ):
+        raise dbus.DBusException('BlueZ is temporarily unavailable')
+    root = bus.get_object(ORG_BLUEZ, '/')
+    objects = dbus.Interface(root, 'org.freedesktop.DBus.ObjectManager').GetManagedObjects(timeout=1)
+    return {
+        str(properties['Address']).upper()
+        for interfaces in objects.values()
+        for properties in [interfaces.get('org.bluez.Device1', {})]
+        if properties.get('Connected') and properties.get('Address')
+    }

--- a/piparty.py
+++ b/piparty.py
@@ -435,11 +435,26 @@ class Menu():
     def check_for_new_moves(self):
         self.enable_bt_scanning(True)
 
-        active_serials = set(self.controller_manager.connected_serials())
+        controllers = self.controller_manager.connected_controllers()
+        if platform in ('linux', 'linux2'):
+            now = time.monotonic()
+            if now >= getattr(self, '_next_connection_check', 0):
+                self._next_connection_check = now + 1.0
+                try:
+                    self._connected_bluetooth_addresses = jm_dbus.get_connected_device_addresses()
+                except (dbus.DBusException, OSError):
+                    # Pairing restarts BlueZ. Keep the last successful snapshot
+                    # rather than interpreting a service failure as disconnects.
+                    pass
+            addresses = getattr(self, '_connected_bluetooth_addresses', None)
+            if addresses is not None:
+                controllers = [controller for controller in controllers
+                               if controller.usb or controller.serial.upper() in addresses]
+        active_serials = {controller.serial for controller in controllers}
         known_serials = {controller.serial for controller in self.moves}
         if active_serials != known_serials:
             disconnected_serials = known_serials - active_serials
-            self.moves = self.controller_manager.connected_controllers()
+            self.moves = controllers
             if disconnected_serials:
                 logger.debug("Move disconnected")
                 self.paired_moves = [
@@ -450,6 +465,22 @@ class Menu():
             if active_serials - known_serials:
                 logger.debug("Move connected")
             self.move_count = self.get_move_count()
+
+    def sync_tracked_controllers(self):
+        """Reconcile identities, including a disconnect/reconnect with equal counts."""
+        connected = {controller.serial for controller in self.moves}
+        for serial in list(self.tracked_moves):
+            if serial in connected:
+                continue
+            self.remove_controller(serial)
+            del self.tracked_moves[serial]
+            if serial == self.admin_move:
+                self.admin_move = None
+        for index, controller in enumerate(self.moves):
+            if controller.usb and not controller.bluetooth:
+                self.pair_usb_move(controller)
+            elif controller.bluetooth and controller.serial not in self.tracked_moves:
+                self.pair_move(controller, index)
 
     # Turn on bluetooth scanning
     def enable_bt_scanning(self, on=True):
@@ -574,8 +605,11 @@ class Menu():
             return
         logger.debug("Removing move: {}".format(move_serial))
         self.kill_controller_proc[move_serial].value = True
-        self.tracked_moves[move_serial].join()
-        self.tracked_moves[move_serial].terminate()
+        process = self.tracked_moves[move_serial]
+        process.join(timeout=1)
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=1)
         #del self.tracked_moves[move_serial] # TODO - why commented?
         del self.force_color[move_serial]
         del self.controller_teams[move_serial]
@@ -749,37 +783,8 @@ class Menu():
                 self.menu_music.load_audio("audio/Menu/music/*")
                 self.menu_music.start_audio_loop()
             self.i = self.i + 1 # Track loop counter
-            if self.controller_manager.count_connected() > len(self.tracked_moves):
-                for move_num, controller in enumerate(self.moves):
-                    # If move is connected via USB, pair it
-                    if controller.usb and not controller.bluetooth:
-                        self.pair_usb_move(controller)
-                    # Track controllers that can provide Bluetooth input.
-                    elif controller.bluetooth:
-                        self.pair_move(controller, move_num)
-            # If the number of tracked moves is greater than the connected ones
-            # kill the tracked moves no longer connected
-            elif(len(self.tracked_moves) > len(self.moves)):
-                connected_serials = [controller.serial for controller in self.moves]
-                tracked_serials = self.tracked_moves.keys()
-                keys_to_kill = []
-                for serial in tracked_serials:
-                    if serial not in connected_serials:
-                        #self.kill_controller_proc[serial].value = True TODO - why is this commented
-                        #check to see if the controller has not been removed already TODO - what is this?
-                        if serial in self.menu_opts.keys():
-                            self.remove_controller(serial)
-                        #self.tracked_moves[serial].join() TODO - ?
-                        #self.tracked_moves[serial].terminate() TODO - ?
-                        keys_to_kill.append(serial) # Add new serials to kill
-
-                # For all keys to kill, remove from tracked_moves
-                for key in keys_to_kill:
-                    del self.tracked_moves[key]
-                    if key == self.admin_move:
-                        self.admin_move = None
-
             self.check_for_new_moves()
+            self.sync_tracked_controllers()
             if len(self.tracked_moves) > 0:
                 self.check_new_admin()
                 self.check_change_mode() # TODO - do we want to make this so only admins can change mode?
@@ -1051,8 +1056,8 @@ class Menu():
 
         # FIX - start_game is always False if there are 0 moves alive
         start_game = len(self.get_game_moves()) > 0
-        for serial in self.menu_opts.keys():
-            if self.out_moves[serial] == Status.ALIVE.value and not self.menu_opts[serial][Opts.RANDOM_START.value]:
+        for serial in self.get_game_moves():
+            if not self.menu_opts[serial][Opts.RANDOM_START.value]:
                 start_game = False
             if self.menu_opts[serial][Opts.RANDOM_START.value] and serial not in self.random_added:
                 self.random_added.append(serial)

--- a/test_controller_disconnect.py
+++ b/test_controller_disconnect.py
@@ -1,0 +1,108 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+import piparty
+import jm_dbus
+import webui
+
+
+def controller(serial, usb=False):
+    return SimpleNamespace(serial=serial, usb=usb, bluetooth=not usb)
+
+
+class DisconnectTest(unittest.TestCase):
+    def menu(self, devices):
+        menu = piparty.Menu.__new__(piparty.Menu)
+        menu.moves = devices[:]
+        menu.paired_moves = [c.serial for c in devices]
+        menu.controller_manager = mock.Mock()
+        menu.controller_manager.connected_controllers.return_value = devices
+        menu.enable_bt_scanning = mock.Mock()
+        menu.get_move_count = lambda: len(menu.moves)
+        return menu
+
+    @mock.patch.object(piparty, 'platform', 'linux')
+    @mock.patch.object(jm_dbus, 'get_connected_device_addresses', return_value={'LIVE'})
+    def test_stale_native_handle_removed_but_usb_preserved(self, query):
+        menu = self.menu([controller('live'), controller('ghost'), controller('usb', True)])
+        menu.check_for_new_moves()
+        self.assertEqual([c.serial for c in menu.moves], ['live', 'usb'])
+        self.assertEqual(menu.move_count, 2)
+        self.assertNotIn('ghost', menu.paired_moves)
+
+    @mock.patch.object(piparty, 'platform', 'linux')
+    @mock.patch.object(jm_dbus, 'get_connected_device_addresses')
+    def test_bluez_outage_keeps_snapshot_then_reconnect_recovers(self, query):
+        menu = self.menu([controller('live'), controller('ghost')])
+        query.return_value = {'LIVE'}
+        menu.check_for_new_moves()
+        menu._next_connection_check = 0
+        query.side_effect = jm_dbus.dbus.DBusException('restarting')
+        menu.check_for_new_moves()
+        self.assertEqual([c.serial for c in menu.moves], ['live'])
+        menu._next_connection_check = 0
+        query.side_effect = None
+        query.return_value = {'LIVE', 'GHOST'}
+        menu.check_for_new_moves()
+        self.assertEqual(len(menu.moves), 2)
+
+    def test_same_count_replacement_removes_old_worker(self):
+        menu = self.menu([controller('new')])
+        menu.tracked_moves = {'old': mock.Mock()}
+        menu.admin_move = 'old'
+        menu.remove_controller = mock.Mock()
+        menu.pair_move = mock.Mock()
+        menu.sync_tracked_controllers()
+        menu.remove_controller.assert_called_once_with('old')
+        menu.pair_move.assert_called_once_with(menu.moves[0], 0)
+        self.assertNotIn('old', menu.tracked_moves)
+        self.assertIsNone(menu.admin_move)
+
+    def test_stale_menu_options_cannot_block_ready_players(self):
+        menu = self.menu([controller('live')])
+        opts = lambda ready: {piparty.Opts.RANDOM_START.value: ready}
+        menu.menu_opts = {'live': opts(True), 'ghost': opts(False)}
+        menu.out_moves = {'live': piparty.Status.ALIVE.value, 'ghost': piparty.Status.ALIVE.value}
+        menu.random_added = ['live']
+        menu.game_mode = piparty.Games.JoustFFA
+        menu.command_from_web = ''
+        menu.start_game = mock.Mock()
+        menu.check_start_game()
+        menu.start_game.assert_called_once_with()
+
+    @mock.patch.object(webui, 'bluetooth_roles', None)
+    @mock.patch.object(webui.psmove_dbus, 'get_registered_controllers')
+    def test_disconnected_debug_entry_does_not_show_stale_values(self, query):
+        query.return_value = [{'address':'AA', 'adapter':'hci0', 'connected':False, 'loaded':True}]
+        ui = webui.WebUI(ns=SimpleNamespace(battery_status={'AA':4},out_moves={'AA':0},controller_update_counts={'AA':10}))
+        data = ui._controller_debug_data()[0]
+        self.assertFalse(data['active'])
+        self.assertEqual(data['battery'], 'Unknown')
+        self.assertIsNone(data['update_count'])
+
+    @mock.patch.object(piparty, 'platform', 'win32')
+    def test_non_linux_keeps_native_connection_tracking(self):
+        menu = self.menu([controller('live')])
+        menu.check_for_new_moves()
+        self.assertEqual(menu.moves[0].serial, 'live')
+
+    @mock.patch.object(jm_dbus.dbus, 'Interface')
+    @mock.patch.object(jm_dbus, 'ensure_process_bus')
+    def test_live_snapshot_filters_disconnected_devices(self, bus, interface):
+        bus.return_value.name_has_owner.return_value = True
+        interface.return_value.GetManagedObjects.return_value = {
+            '/connected': {'org.bluez.Device1': {'Address':'aa:bb', 'Connected':True}},
+            '/saved': {'org.bluez.Device1': {'Address':'cc:dd', 'Connected':False}},
+            '/adapter': {'org.bluez.Adapter1': {'Address':'ee:ff'}},
+        }
+        self.assertEqual(jm_dbus.get_connected_device_addresses(), {'AA:BB'})
+
+    @mock.patch.object(jm_dbus, 'ensure_process_bus')
+    def test_unavailable_service_is_not_empty_connections(self, bus):
+        bus.return_value.name_has_owner.return_value = False
+        with self.assertRaises(jm_dbus.dbus.DBusException):
+            jm_dbus.get_connected_device_addresses()
+        bus.return_value.get_object.assert_not_called()
+
+
+if __name__ == '__main__': unittest.main()

--- a/webui.py
+++ b/webui.py
@@ -335,7 +335,7 @@ class WebUI():
 
         for controller in controllers:
             address = controller['address'].upper()
-            battery = battery_status.get(address)
+            battery = battery_status.get(address) if controller['connected'] else None
             controller['status'] = (
                 'Connected' if controller['connected']
                 else 'Paired, not connected'
@@ -343,9 +343,11 @@ class WebUI():
             controller['battery'] = common.battery_levels.get(battery, 'Unknown')
             controller['battery_code'] = battery
             controller['active'] = (
-                None if address not in out_moves else out_moves[address] == 0
+                False if not controller['connected'] else (
+                    None if address not in out_moves else out_moves[address] == 0
+                )
             )
-            controller['update_count'] = update_counts.get(address)
+            controller['update_count'] = update_counts.get(address) if controller['connected'] else None
             controller['report_gap'] = report_gaps.get(address) if controller['connected'] else None
 
         if bluetooth_roles is not None:


### PR DESCRIPTION
A disconnected PS Move could remain in JoustMania’s player list: three connected, ready players were blocked because the menu still counted a fourth stale controller. Its old battery reading and active status also remained visible in System Debug.

On Linux, reconcile native controller entries against BlueZ’s current connected-device snapshot once per second. Preserve USB controllers and the last successful snapshot during BlueZ service failures. Reconcile tracked players by identity, including equal-count replacements, and only let current eligible players block automatic startup. Worker cleanup now has bounded waits. Disconnected debug entries clear active status, battery and update count.

This uses actual Bluetooth connection state, not a report-silence timeout. It corrects menu state when a native handle remains stale; it does not change PSMoveAPI’s device-handle lifecycle or implement in-game disconnect recovery. No new dependencies are required.

Validation:
- 29 Python tests passed, including stale native handles, readiness blocked by old menu entries, equal-count replacements, BlueZ outages/recovery, USB preservation and non-Linux behavior.
- JavaScript controller/debug UI tests passed; git diff --check passed.
- Loaded on the Pi: menu count matches the three connected controllers; disconnected entries show inactive, Unknown battery and no update count.
- The original missed-disconnect event has not been reproduced end-to-end after the change; regression tests simulate its retained native/player state.
