### PR TITLE
Fill adapters to five and preview the next USB pairing target

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,9 @@ to JoustMania, not over-air timing or motion-to-game latency. History resets on
 reconnection. Timing uses Python's standard library; no additional setup packages
 or packet-capture tools are required.
 
-System Debug shows the next USB pairing adapter and lets you choose a different
-adapter for one successful pairing. Connect one controller over USB at a time.
+System Debug selects the next USB pairing adapter beside its heading. Select a
+different adapter there to override one successful pairing; the selection then
+returns to the algorithm’s next target. Connect one controller over USB at a time.
 Automatic assignment fills powered adapters to five in hci order, then cycles
 through all adapters. Counts combine current PS Move connections with successful
 USB assignments in this session; restarting clears session reservations. Saved

--- a/README.md
+++ b/README.md
@@ -343,3 +343,11 @@ Hover over p95 for p99 and counts of pauses over 50/100 ms. These measure delive
 to JoustMania, not over-air timing or motion-to-game latency. History resets on
 reconnection. Timing uses Python's standard library; no additional setup packages
 or packet-capture tools are required.
+
+System Debug shows the next USB pairing adapter and lets you choose a different
+adapter for one successful pairing. Connect one controller over USB at a time.
+Automatic assignment fills powered adapters to five in hci order, then cycles
+through all adapters. Counts combine current PS Move connections with successful
+USB assignments in this session; restarting clears session reservations. Saved
+registrations alone do not count, and existing wireless connections are not moved.
+A failed attempt keeps the override; unplugging its adapter returns to automatic.

--- a/pair.py
+++ b/pair.py
@@ -1,4 +1,5 @@
 import controller_manager
+import pairing_plan
 import os
 import logging
 
@@ -16,8 +17,9 @@ class Pair():
     """
     Manage paring move controllers to the server
     """
-    def __init__(self):
+    def __init__(self, ns=None):
         """Use DBus to find bluetooth controllers"""
+        self.ns = ns
         self.hci_dict = {}
         self.bt_devices = {}
         self.update_adapters()
@@ -61,16 +63,13 @@ class Pair():
             self.bt_devices = {}
 
     def get_lowest_bt_device(self):
-        num = 9999999
-        print(self.bt_devices)
-        for dev in self.bt_devices.keys():
-            if len(self.bt_devices[dev]) < num:
-                num = len(self.bt_devices[dev])
-
-        for dev in self.bt_devices.keys():
-            if len(self.bt_devices[dev]) == num:
-                return dev
-        return ''
+        # Compatibility path for callers without shared UI selection state.
+        for address, devices in self.bt_devices.items():
+            if len(devices) < 5:
+                return address
+        if not self.bt_devices:
+            return ''
+        return min(self.bt_devices, key=lambda address: len(self.bt_devices[address]))
 
     def pair_move(self, move_controller):
         if move_controller and move_controller.serial:
@@ -81,10 +80,16 @@ class Pair():
                 # A saved BlueZ registration does not prove that the controller
                 # still stores this Pi as its Bluetooth host. Pairing over USB
                 # rewrites that address after use with another computer.
-                host_address = self.get_lowest_bt_device()
+                ns = getattr(self, 'ns', None)
+                host_address = pairing_plan.begin(ns) if ns is not None else self.get_lowest_bt_device()
                 if not host_address:
                     return False
-                paired = controller_manager.pair_controller(host_address)
+                paired = False
+                try:
+                    paired = controller_manager.pair_controller(host_address)
+                finally:
+                    if ns is not None:
+                        pairing_plan.finish(ns, move_controller.serial, host_address, paired)
                 if paired:
                     # BlueZ may need a few seconds to publish the registration.
                     # Reserve it immediately so another controller paired in

--- a/pairing_plan.py
+++ b/pairing_plan.py
@@ -1,0 +1,115 @@
+"""Shared next-pairing selection for the menu and debug web process."""
+import time
+
+
+def initialize(ns, manager):
+    ns.pairing_state = manager.dict(layout=[], reservations={}, override='', cursor='', busy=False, error='', refreshed=0.0)
+    ns.pairing_lock = manager.RLock()
+
+
+def read_layout():
+    import dbus
+    import jm_dbus
+    import psmove_dbus
+    bus = jm_dbus.ensure_process_bus()
+    if not bus.name_has_owner(jm_dbus.ORG_BLUEZ):
+        raise RuntimeError('Bluetooth service is unavailable')
+    objects = dbus.Interface(bus.get_object(jm_dbus.ORG_BLUEZ, '/'),
+                             'org.freedesktop.DBus.ObjectManager').GetManagedObjects(timeout=1)
+    layout = []
+    for path, interfaces in objects.items():
+        adapter = interfaces.get('org.bluez.Adapter1')
+        if not adapter or not adapter.get('Powered'):
+            continue
+        connected = []
+        for device_path, device_interfaces in objects.items():
+            device = device_interfaces.get('org.bluez.Device1', {})
+            if str(device_path).startswith(str(path) + '/') and device.get('Connected') and psmove_dbus.is_psmove_device(device):
+                connected.append(str(device['Address']).upper())
+        layout.append(dict(name=str(path).rsplit('/', 1)[-1], address=str(adapter['Address']).upper(), connected=connected))
+    return sorted(layout, key=lambda a: (int(a['name'][3:]), a['address']))
+
+
+def refresh(ns, force=False):
+    state, lock = ns.pairing_state, ns.pairing_lock
+    with lock:
+        if state['busy'] or (not force and time.monotonic() - state['refreshed'] < 1):
+            return
+        try:
+            layout = read_layout()
+        except Exception as error:
+            state['error'] = str(error)
+            state['refreshed'] = time.monotonic()
+            return
+        state['layout'] = layout
+        state['refreshed'] = time.monotonic()
+        state['error'] = ''
+        if state['override'] and state['override'] not in {a['address'] for a in layout}:
+            state['override'] = ''
+
+
+def describe(state):
+    reservations = dict(state['reservations'])
+    adapters = []
+    for adapter in state['layout']:
+        members = set(adapter['connected'])
+        # A later USB pairing supersedes a previous assignment for that serial.
+        members = {serial for serial in members if reservations.get(serial, adapter['address']) == adapter['address']}
+        members.update(serial for serial, address in reservations.items() if address == adapter['address'])
+        adapters.append(dict(name=adapter['name'], address=adapter['address'], count=len(members)))
+    automatic = next((a['address'] for a in adapters if a['count'] < 5), '')
+    if adapters and not automatic:
+        addresses = [a['address'] for a in adapters]
+        cursor = state['cursor']
+        automatic = addresses[(addresses.index(cursor) + 1) % len(addresses)] if cursor in addresses else addresses[0]
+    override = state['override']
+    return dict(available=True, adapters=adapters, automatic=automatic,
+                selected=override or automatic, override=override, busy=state['busy'], error=state['error'])
+
+
+def status(ns):
+    if not hasattr(ns, 'pairing_state'):
+        return dict(available=False, adapters=[], selected='', automatic='', override='', busy=False, error='')
+    refresh(ns)
+    with ns.pairing_lock:
+        return describe(ns.pairing_state)
+
+
+def select(ns, address):
+    refresh(ns, force=True)
+    with ns.pairing_lock:
+        state = ns.pairing_state
+        if state['busy']:
+            raise ValueError('A pairing is already in progress. Try again after it finishes.')
+        if state['error']:
+            raise ValueError(state['error'])
+        if address and address not in {a['address'] for a in state['layout']}:
+            raise ValueError('That adapter is no longer available.')
+        state['override'] = address
+        return describe(state)
+
+
+def begin(ns):
+    refresh(ns, force=True)
+    with ns.pairing_lock:
+        state = ns.pairing_state
+        target = describe(state)['selected']
+        if state['busy'] or state['error'] or not target:
+            return ''
+        state['busy'] = True
+        return target
+
+
+def finish(ns, serial, target, succeeded):
+    with ns.pairing_lock:
+        state = ns.pairing_state
+        if succeeded:
+            reservations = dict(state['reservations'])
+            reservations[serial.upper()] = target
+            state['reservations'] = reservations
+            state['cursor'] = target
+            state['override'] = ''
+            state['error'] = ''
+        state['busy'] = False
+        # Keep the successful reservation even before BlueZ publishes the link.
+        state['refreshed'] = 0.0

--- a/piparty.py
+++ b/piparty.py
@@ -35,6 +35,7 @@ if __name__ == "__main__" and sys.platform.startswith("win"):
 
     _freeze_support()
 
+import pairing_plan
 import controller_manager
 import runtime_platform
 import common, colors, webui
@@ -352,6 +353,8 @@ class Menu():
         self.ns.status = dict()
         self.ns.settings = dict()
         self.ns.battery_status = dict()
+        if platform in ("linux", "linux2"):
+            pairing_plan.initialize(self.ns, self.joust_manager)
         self.command_from_web = ''
         self.initialize_settings()
         self.update_settings_file() # Update settings from joustmania.yaml
@@ -400,7 +403,7 @@ class Menu():
         self.teams = {} # Serial to team list TODO - seems to be the same as controller_teams
         self.game_mode = Games[self.ns.settings['current_game']] # Get game mode from ns (which is shared with web admin)
         self.old_game_mode = self.game_mode #Previous game mode
-        self.pair = pair.Pair() # Start bluetooth pairing
+        self.pair = pair.Pair(self.ns) if platform in ("linux", "linux2") else pair.Pair() # Start bluetooth pairing
         self.bluetooth_missing = False
         self.bluetooth_pairing_notices = set()
 

--- a/templates/controller_debug.html
+++ b/templates/controller_debug.html
@@ -38,16 +38,6 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
     <section aria-labelledby="pairing-heading">
         <h3 id="pairing-heading">Next USB pairing</h3>
         <p id="pairing-status" role="status">{{ 'Checking next adapter…' if pairing.available else 'Adapter selection unavailable on this platform.' }}</p>
-        <form id="pairing-target-form">
-            <fieldset id="pairing-target-options" {% if not pairing.available or pairing.busy %}disabled{% endif %}>
-                <legend>Adapter for the next controller</legend>
-                <label><input type="radio" name="pairing-target" value="" {% if not pairing.override %}checked{% endif %}> Automatic</label>
-                {% for adapter in pairing.adapters %}
-                <label><input type="radio" name="pairing-target" value="{{ adapter.address }}" {% if pairing.override == adapter.address %}checked{% endif %}>
-                    {{ adapter.name }} ({{ adapter.address }}) — {{ adapter.count }} assigned</label>
-                {% endfor %}
-            </fieldset>
-        </form>
         <p class="diagnostic-note">Automatic fills each adapter to five controllers in adapter order, then cycles through all adapters.
         Counts include connected controllers and successful USB pairings this session. A manual choice applies to one successful pairing, then clears.
         Connect one controller by USB at a time. This changes the host saved by that controller; it does not move existing wireless connections.</p>
@@ -56,7 +46,11 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
     <div id="bluetooth-adapter-body">
     {% for adapter in adapters %}
     <section class="adapter-section" data-adapter-section="{{ adapter.name }}">
-        <h3><span class="adapter-name">{{ adapter.name }}</span> — <span class="adapter-address">{{ adapter.address }}</span></h3>
+        <h3><input type="radio" class="pairing-target" name="pairing-target" value="{{ adapter.address }}"
+                   aria-label="Use {{ adapter.name }} for the next USB pairing"
+                   {% if pairing.selected == adapter.address %}checked{% endif %}
+                   {% if not pairing.available or pairing.busy or pairing.error %}disabled{% endif %}>
+            <span class="adapter-name">{{ adapter.name }}</span> — <span class="adapter-address">{{ adapter.address }}</span></h3>
         <table>
         <thead><tr>
             <th>Chipset</th><th>USB device</th><th>USB link</th>
@@ -177,30 +171,19 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
             (state.error ? 'Pairing unavailable: ' + state.error :
             (state.busy ? 'Pairing with ' : 'Next controller: ') +
             (selected ? selected.name + ' (' + selected.address + ')' : 'No powered adapters') +
-            (state.override ? ' — one-time choice' : ' — automatic'));
-        const options = document.getElementById('pairing-target-options');
-        options.textContent = '';
-        const legend = document.createElement('legend');
-        legend.textContent = 'Adapter for the next controller'; options.appendChild(legend);
-        const choices = [{address: '', label: 'Automatic'}].concat(state.adapters.map(adapter => ({
-            address: adapter.address, label: adapter.name + ' (' + adapter.address + ') — ' + adapter.count + ' assigned' +
-                (adapter.address === state.automatic ? ' — automatic next' : '')
-        })));
-        choices.forEach(choice => {
-            const label = document.createElement('label');
-            const input = document.createElement('input');
-            input.type = 'radio'; input.name = 'pairing-target'; input.value = choice.address;
-            input.checked = choice.address === state.override;
-            label.appendChild(input); label.appendChild(document.createTextNode(' ' + choice.label + ' '));
-            options.appendChild(label);
+            (state.override ? ' — next pairing only' : ''));
+        document.querySelectorAll('.pairing-target').forEach(input => {
+            input.checked = input.value === state.selected;
+            input.disabled = pairingPending || state.busy || !state.available || Boolean(state.error) ||
+                !state.adapters.some(adapter => adapter.address === input.value);
+            const adapter = state.adapters.find(adapter => adapter.address === input.value);
+            input.title = adapter ? adapter.count + ' controllers assigned; select for the next USB pairing' : 'Unavailable';
         });
-        options.disabled = pairingPending || state.busy || !state.available || Boolean(state.error);
     }
-    document.getElementById('pairing-target-form').addEventListener('submit', event => event.preventDefault());
-    document.getElementById('pairing-target-form').addEventListener('change', async function (event) {
+    document.addEventListener('change', async function (event) {
         if (event.target.name !== 'pairing-target' || pairingPending) return;
         pairingPending = true;
-        document.getElementById('pairing-target-options').disabled = true;
+        document.querySelectorAll('.pairing-target').forEach(input => {input.disabled = true;});
         try {
             const response = await fetch('/debug/pairing-target', {method: 'POST', body: new URLSearchParams({address: event.target.value})});
             const state = await response.json();

--- a/templates/controller_debug.html
+++ b/templates/controller_debug.html
@@ -35,6 +35,24 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
     <p class="diagnostic-note">Live rates are HCI packets handled by each adapter. With controllers connected,
     packet rates vary with controller type and traffic. Assessment summarizes connected controllers using their p95 report gaps.
     Mixed results are listed separately; this is a connection assessment, not an adapter speed rating.</p>
+    <section aria-labelledby="pairing-heading">
+        <h3 id="pairing-heading">Next USB pairing</h3>
+        <p id="pairing-status" role="status">{{ 'Checking next adapter…' if pairing.available else 'Adapter selection unavailable on this platform.' }}</p>
+        <form id="pairing-target-form">
+            <fieldset id="pairing-target-options" {% if not pairing.available or pairing.busy %}disabled{% endif %}>
+                <legend>Adapter for the next controller</legend>
+                <label><input type="radio" name="pairing-target" value="" {% if not pairing.override %}checked{% endif %}> Automatic</label>
+                {% for adapter in pairing.adapters %}
+                <label><input type="radio" name="pairing-target" value="{{ adapter.address }}" {% if pairing.override == adapter.address %}checked{% endif %}>
+                    {{ adapter.name }} ({{ adapter.address }}) — {{ adapter.count }} assigned</label>
+                {% endfor %}
+            </fieldset>
+        </form>
+        <p class="diagnostic-note">Automatic fills each adapter to five controllers in adapter order, then cycles through all adapters.
+        Counts include connected controllers and successful USB pairings this session. A manual choice applies to one successful pairing, then clears.
+        Connect one controller by USB at a time. This changes the host saved by that controller; it does not move existing wireless connections.</p>
+        <p id="pairing-error" role="alert"></p>
+    </section>
     <div id="bluetooth-adapter-body">
     {% for adapter in adapters %}
     <section class="adapter-section" data-adapter-section="{{ adapter.name }}">
@@ -151,6 +169,51 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
 <script>
 (function () {
     let lastTime = Date.now();
+    let pairingPending = false;
+    function renderPairing(state) {
+        if (!state) return;
+        const selected = state.adapters.find(adapter => adapter.address === state.selected);
+        document.getElementById('pairing-status').textContent = !state.available ? 'Adapter selection unavailable on this platform.' :
+            (state.error ? 'Pairing unavailable: ' + state.error :
+            (state.busy ? 'Pairing with ' : 'Next controller: ') +
+            (selected ? selected.name + ' (' + selected.address + ')' : 'No powered adapters') +
+            (state.override ? ' — one-time choice' : ' — automatic'));
+        const options = document.getElementById('pairing-target-options');
+        options.textContent = '';
+        const legend = document.createElement('legend');
+        legend.textContent = 'Adapter for the next controller'; options.appendChild(legend);
+        const choices = [{address: '', label: 'Automatic'}].concat(state.adapters.map(adapter => ({
+            address: adapter.address, label: adapter.name + ' (' + adapter.address + ') — ' + adapter.count + ' assigned' +
+                (adapter.address === state.automatic ? ' — automatic next' : '')
+        })));
+        choices.forEach(choice => {
+            const label = document.createElement('label');
+            const input = document.createElement('input');
+            input.type = 'radio'; input.name = 'pairing-target'; input.value = choice.address;
+            input.checked = choice.address === state.override;
+            label.appendChild(input); label.appendChild(document.createTextNode(' ' + choice.label + ' '));
+            options.appendChild(label);
+        });
+        options.disabled = pairingPending || state.busy || !state.available || Boolean(state.error);
+    }
+    document.getElementById('pairing-target-form').addEventListener('submit', event => event.preventDefault());
+    document.getElementById('pairing-target-form').addEventListener('change', async function (event) {
+        if (event.target.name !== 'pairing-target' || pairingPending) return;
+        pairingPending = true;
+        document.getElementById('pairing-target-options').disabled = true;
+        try {
+            const response = await fetch('/debug/pairing-target', {method: 'POST', body: new URLSearchParams({address: event.target.value})});
+            const state = await response.json();
+            if (!response.ok) throw new Error(state.error || 'Unable to select adapter');
+            document.getElementById('pairing-error').textContent = '';
+            pairingPending = false;
+            renderPairing(state);
+        } catch (error) {
+            document.getElementById('pairing-error').textContent = error.message;
+        } finally {
+            pairingPending = false;
+        }
+    });
     let hotspotPending = false;
     function renderHotspot(state) {
         document.getElementById('hotspot-status').textContent = state.busy ? 'Changing Wi-Fi hotspot…' :
@@ -384,6 +447,7 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
                 row.dataset.rx = adapter.rx_acl; row.dataset.tx = adapter.tx_acl;
             });
             renderControllers(data.controllers, seconds);
+            if (!pairingPending) renderPairing(data.pairing);
             lastTime = now;
         }).catch(function () {});
     }, 1000);

--- a/test_controller_role_ui.js
+++ b/test_controller_role_ui.js
@@ -89,24 +89,26 @@ vm.runInNewContext(script.replace('}());', 'globalThis.renderControllers = rende
     assert.equal(context.connectionAssessment(adapter, [link(36), link(40)]), 'Slow connections (2)');
     assert.equal(context.connectionAssessment(adapter, [link(24)]), 'Borderline connection');
     assert.equal(context.connectionAssessment(adapter, [link(null)]), 'Measuring connections…');
-    elements['pairing-target-options'] = node();
+    const pairingInputs = [{value:'AA'}, {value:'BB'}];
+    context.document.querySelectorAll = selector => selector === '.pairing-target' ? pairingInputs : [body, unknown];
     context.document.createTextNode = text => ({textContent: text});
     const plan = {available: true, adapters: [{name:'hci0', address:'AA', count:4}, {name:'hci1', address:'BB', count:0}],
         automatic:'AA', selected:'AA', override:'', busy:false, error:''};
     context.renderPairing(plan);
-    assert.match(element('pairing-status').textContent, /Next controller: hci0.*automatic/);
+    assert.match(element('pairing-status').textContent, /Next controller: hci0/);
     let chosen;
     context.fetch = async (url, options) => {
         assert.equal(url, '/debug/pairing-target');
         chosen = options.body.get('address');
         return {ok:true, json:async () => ({...plan, override:chosen, selected:chosen || plan.automatic})};
     };
-    await element('pairing-target-form').change({target:{name:'pairing-target',value:'BB'}});
+    await handlers.change({target:{name:'pairing-target',value:'BB'}});
     assert.equal(chosen, 'BB');
-    assert.match(element('pairing-status').textContent, /hci1.*one-time choice/);
+    assert.match(element('pairing-status').textContent, /hci1.*next pairing only/);
     context.renderPairing({...plan, busy:true});
-    assert.equal(element('pairing-target-options').disabled, true);
+    assert(pairingInputs.every(input => input.disabled));
     context.renderPairing(plan);
-    assert.equal(element('pairing-target-options').children[1].children[0].checked, true);
+    assert.equal(pairingInputs[0].checked, true);
+    assert.equal(pairingInputs[1].checked, false);
     console.log('Controller and pairing target UI tests passed');
 })().catch(error => {console.error(error); process.exitCode = 1;});

--- a/test_controller_role_ui.js
+++ b/test_controller_role_ui.js
@@ -34,7 +34,7 @@ const context = {
         return {ok, async json() {return ok ? {role: 'Peripheral'} : {error: 'Switch rejected'};}};
     }
 };
-vm.runInNewContext(script.replace('}());', 'globalThis.renderControllers = renderControllers; globalThis.connectionAssessment = connectionAssessment;}());'), context);
+vm.runInNewContext(script.replace('}());', 'globalThis.renderControllers = renderControllers; globalThis.connectionAssessment = connectionAssessment; globalThis.renderPairing = renderPairing;}());'), context);
 (async () => {
     await element('all-peripheral').click();
     assert.equal(requests.length, 2);
@@ -89,5 +89,24 @@ vm.runInNewContext(script.replace('}());', 'globalThis.renderControllers = rende
     assert.equal(context.connectionAssessment(adapter, [link(36), link(40)]), 'Slow connections (2)');
     assert.equal(context.connectionAssessment(adapter, [link(24)]), 'Borderline connection');
     assert.equal(context.connectionAssessment(adapter, [link(null)]), 'Measuring connections…');
-    console.log('Controller role, report gap and assessment UI tests passed');
+    elements['pairing-target-options'] = node();
+    context.document.createTextNode = text => ({textContent: text});
+    const plan = {available: true, adapters: [{name:'hci0', address:'AA', count:4}, {name:'hci1', address:'BB', count:0}],
+        automatic:'AA', selected:'AA', override:'', busy:false, error:''};
+    context.renderPairing(plan);
+    assert.match(element('pairing-status').textContent, /Next controller: hci0.*automatic/);
+    let chosen;
+    context.fetch = async (url, options) => {
+        assert.equal(url, '/debug/pairing-target');
+        chosen = options.body.get('address');
+        return {ok:true, json:async () => ({...plan, override:chosen, selected:chosen || plan.automatic})};
+    };
+    await element('pairing-target-form').change({target:{name:'pairing-target',value:'BB'}});
+    assert.equal(chosen, 'BB');
+    assert.match(element('pairing-status').textContent, /hci1.*one-time choice/);
+    context.renderPairing({...plan, busy:true});
+    assert.equal(element('pairing-target-options').disabled, true);
+    context.renderPairing(plan);
+    assert.equal(element('pairing-target-options').children[1].children[0].checked, true);
+    console.log('Controller and pairing target UI tests passed');
 })().catch(error => {console.error(error); process.exitCode = 1;});

--- a/test_pairing_plan.py
+++ b/test_pairing_plan.py
@@ -1,0 +1,79 @@
+import threading
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+import pairing_plan
+import pair
+import webui
+
+
+def namespace():
+    return SimpleNamespace(pairing_lock=threading.RLock(), pairing_state=dict(layout=[], reservations={}, override='', cursor='', busy=False, error='', refreshed=0))
+
+
+def layout():
+    return [dict(name='hci0', address='AA', connected=[]), dict(name='hci1', address='BB', connected=[])]
+
+
+class PairingPlanTest(unittest.TestCase):
+    def setUp(self):
+        self.ns = namespace()
+        self.patch = mock.patch.object(pairing_plan, 'read_layout', side_effect=layout)
+        self.patch.start()
+        self.addCleanup(self.patch.stop)
+
+    def test_fill_five_then_round_robin_with_delayed_connections(self):
+        targets = []
+        for index in range(14):
+            target = pairing_plan.begin(self.ns)
+            targets.append(target)
+            pairing_plan.finish(self.ns, str(index), target, True)
+        self.assertEqual(targets, ['AA'] * 5 + ['BB'] * 5 + ['AA', 'BB', 'AA', 'BB'])
+
+    def test_one_time_override_only_consumed_on_success(self):
+        pairing_plan.select(self.ns, 'BB')
+        target = pairing_plan.begin(self.ns)
+        self.assertEqual(target, 'BB')
+        with self.assertRaises(ValueError): pairing_plan.select(self.ns, 'AA')
+        pairing_plan.finish(self.ns, 'one', target, False)
+        self.assertEqual(pairing_plan.status(self.ns)['override'], 'BB')
+        target = pairing_plan.begin(self.ns)
+        pairing_plan.finish(self.ns, 'one', target, True)
+        state = pairing_plan.status(self.ns)
+        self.assertEqual(state['override'], '')
+        self.assertEqual(state['selected'], 'AA')
+
+    def test_connections_and_reservations_not_double_counted(self):
+        self.ns.pairing_state.update(layout=[dict(name='hci0', address='AA', connected=['ONE'])], reservations={'ONE':'AA'})
+        self.assertEqual(pairing_plan.describe(self.ns.pairing_state)['adapters'][0]['count'], 1)
+
+    def test_removed_override_falls_back_and_unavailable_service_blocks_pairing(self):
+        pairing_plan.select(self.ns, 'BB')
+        with mock.patch.object(pairing_plan, 'read_layout', return_value=layout()[:1]):
+            pairing_plan.refresh(self.ns, force=True)
+        self.assertEqual(pairing_plan.describe(self.ns.pairing_state)['selected'], 'AA')
+        with mock.patch.object(pairing_plan, 'read_layout', side_effect=RuntimeError('offline')):
+            self.assertEqual(pairing_plan.begin(self.ns), '')
+
+    def test_pair_move_passes_only_selected_adapter_to_existing_command(self):
+        pairing = pair.Pair.__new__(pair.Pair)
+        pairing.ns = self.ns
+        pairing.bt_devices = {}
+        pairing.update_adapters = mock.Mock()
+        pairing_plan.select(self.ns, 'BB')
+        with mock.patch.object(pair.controller_manager, 'pair_controller', return_value=True) as native:
+            self.assertTrue(pairing.pair_move(SimpleNamespace(serial='ONE', usb=True, bluetooth=False)))
+        native.assert_called_once_with('BB')
+        self.assertEqual(pairing_plan.status(self.ns)['selected'], 'AA')
+
+    def test_target_route_validates_and_can_return_to_automatic(self):
+        self.ns.status = {}; self.ns.battery_status = {}
+        client = webui.WebUI(ns=self.ns).app.test_client()
+        self.assertEqual(client.post('/debug/pairing-target', data={'address':'invalid'}).status_code, 409)
+        result = client.post('/debug/pairing-target', data={'address':'bb'})
+        self.assertEqual(result.json['selected'], 'BB')
+        self.assertEqual(client.post('/debug/pairing-target', data={'address':''}).json['selected'], 'AA')
+        self.assertEqual(client.get('/debug/pairing-target').status_code, 405)
+
+
+if __name__ == '__main__': unittest.main()

--- a/webui.py
+++ b/webui.py
@@ -1,3 +1,4 @@
+import pairing_plan
 from multiprocessing import Queue, Manager, Process
 import socket
 import subprocess
@@ -110,6 +111,7 @@ class WebUI():
         self.app.add_url_rule('/debug','debug',self.controller_debug)
         self.app.add_url_rule('/debug/controllers','controller_debug_legacy',self.controller_debug_legacy)
         self.app.add_url_rule('/debug/data','debug_data',self.debug_data)
+        self.app.add_url_rule('/debug/pairing-target', 'pairing_target', self.change_pairing_target, methods=['POST'])
         self.app.add_url_rule('/debug/controller-role', 'controller_role', self.change_controller_role, methods=['POST'])
         self.app.add_url_rule('/debug/access-point', 'access_point', self.change_access_point, methods=['POST'])
         self.app.add_url_rule(
@@ -192,7 +194,17 @@ class WebUI():
             "adapters": bluetooth_diagnostics.get_adapters(),
             "controllers": self._controller_debug_data(),
             "access_point": access_point.status(),
+            "pairing": pairing_plan.status(self.ns),
         }
+
+    def change_pairing_target(self):
+        if not hasattr(self.ns, 'pairing_state'):
+            return {'error': 'Adapter selection is only available on Linux.'}, 501
+        address = request.form.get('address', '').strip().upper()
+        try:
+            return pairing_plan.select(self.ns, address)
+        except ValueError as error:
+            return {'error': str(error)}, 409
 
     def change_controller_role(self):
         if bluetooth_roles is None:
@@ -386,6 +398,7 @@ class WebUI():
         return render_template(
             'controller_debug.html',
             access_point=access_point.status(),
+            pairing=pairing_plan.status(self.ns),
             controllers=controllers,
             adapters=adapters,
         )


### PR DESCRIPTION
USB pairing previously chose the least-populated adapter without showing the next target. The default now fills each powered adapter to five PS Moves in hci order, then cycles through all adapters. System Debug previews that target and places a single-choice selector beside each adapter heading. The algorithm’s next target is selected by default; a manual selection applies to the next successful pairing and then returns to the algorithm. There is no separate Automatic option.

The menu and web process share the same allocation state. Counts combine connected PS Moves with successful USB assignments during this session, so delayed wireless connections do not keep choosing the same adapter. Only a successful pairing consumes the override; a failure keeps it, and removing its adapter returns to automatic. Selection is locked during an active pairing. The existing pairing command remains unchanged: one USB controller is connected at a time.

No new dependencies. USB host assignments affect future wireless reconnects; this does not migrate existing links. Session reservations reset when JoustMania restarts.

Validation: 27 Python tests and JavaScript UI tests passed, including fill-five/round-robin sequencing, one-use overrides, failure retention, hot-unplug, delayed connections, deduplication and route validation. Verified the live QGOO target, manual selection and return to the algorithm on the Pi without triggering a hardware pairing. Multi-adapter allocation and pairing success/failure were tested with mocks, not multiple physical dongles.

Stacked on #381 so this draft shows only the pairing-target changes.
