### PR TITLE
Add controller Identify and Unpair actions and simplify debug status

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,3 +352,5 @@ through all adapters. Counts combine current PS Move connections with successful
 USB assignments in this session; restarting clears session reservations. Saved
 registrations alone do not count, and existing wireless connections are not moved.
 A failed attempt keeps the override; unplugging its adapter returns to automatic.
+
+System Debug provides **Identify** beside each controller status: it shows white for three seconds, then restores the color currently requested by the game. **Unpair** in the last column removes that controller’s host registrations (including saved registrations on unavailable adapters); reconnect it by USB to pair again. Individual role switches appear only for connected controllers with an available adapter and known role. Model labels distinguish ZCM1 (PS3) and ZCM2 (PS4).

--- a/controller_manager.py
+++ b/controller_manager.py
@@ -57,8 +57,21 @@ class ControllerManager:
         self.gyroscope = multiprocessing.RawArray(ctypes.c_float, _VECTOR_SIZE)
         self.battery = multiprocessing.RawArray(ctypes.c_int, MAX_CONTROLLERS)
 
+        self.identify_until = multiprocessing.RawArray(ctypes.c_double, MAX_CONTROLLERS)
         self.leds = multiprocessing.RawArray(ctypes.c_ubyte, _VECTOR_SIZE)
         self.rumble = multiprocessing.RawArray(ctypes.c_ubyte, MAX_CONTROLLERS)
+
+    def request_identify(self, serial):
+        for index in self.active_controller_indices():
+            if self.index_to_serial[index].upper() == serial.upper():
+                self.identify_until[index] = time.monotonic() + 3
+                return True
+        return False
+
+    def output_color(self, index):
+        if time.monotonic() < self.identify_until[index]:
+            return (255, 255, 255)
+        return tuple(self.leds[index * 3:index * 3 + 3])
 
     def active_controller_indices(self):
         return [
@@ -214,6 +227,7 @@ def _api_process_main(manager):
             """
             controller_index = controller_index_for(psmove_controller.serial)
             manager.report_timing.reset(controller_index)
+            manager.identify_until[controller_index] = 0
             manager.active[controller_index] = 1
             manager.usb[controller_index] = int(psmove_controller.usb)
             manager.bluetooth[controller_index] = int(psmove_controller.bluetooth)
@@ -252,11 +266,11 @@ def _api_process_main(manager):
 
             # These assignments update the upstream ctypes ControllerStruct.
             # Native PSMoveAPI sends them after this callback returns.
-            offset = controller_index * 3
+            red, green, blue = manager.output_color(controller_index)
             psmove_controller.color = psmoveapi.RGB(
-                manager.leds[offset] / 255.0,
-                manager.leds[offset + 1] / 255.0,
-                manager.leds[offset + 2] / 255.0,
+                red / 255.0,
+                green / 255.0,
+                blue / 255.0,
             )
             psmove_controller.rumble = manager.rumble[controller_index] / 255.0
 
@@ -267,6 +281,7 @@ def _api_process_main(manager):
             """
             controller_index = local_controller_indices.get(psmove_controller.serial)
             if controller_index is not None:
+                manager.identify_until[controller_index] = 0
                 manager.active[controller_index] = 0
                 manager.report_timing.reset(controller_index)
                 manager.usb[controller_index] = 0

--- a/psmove_dbus.py
+++ b/psmove_dbus.py
@@ -168,3 +168,28 @@ def get_registered_controllers():
             })
 
     return sorted(controllers, key=lambda item: (item['adapter'], item['address']))
+
+
+def unpair_controller(address):
+    """Remove only this PS Move's live and saved host registrations."""
+    import re
+    import shutil
+    address = address.upper()
+    if not re.fullmatch(r'(?:[0-9A-F]{2}:){5}[0-9A-F]{2}', address):
+        raise ValueError('Invalid controller address.')
+    records = [c for c in get_registered_controllers() if c['address'].upper() == address]
+    if not records:
+        raise ValueError('Controller is no longer registered.')
+    for controller in records:
+        if controller['loaded']:
+            jm_dbus.remove_device(controller['adapter'], controller['device_name'])
+        else:
+            adapter = controller['adapter_address'].upper()
+            if not re.fullmatch(r'(?:[0-9A-F]{2}:){5}[0-9A-F]{2}', adapter):
+                raise ValueError('Invalid saved adapter address.')
+            directory = Path('/var/lib/bluetooth') / adapter / address
+            try:
+                shutil.rmtree(directory)
+            except FileNotFoundError:
+                pass
+    return len(records)

--- a/templates/controller_debug.html
+++ b/templates/controller_debug.html
@@ -19,7 +19,7 @@
 .rate-slow { background-color: #ff8080; }
 .rate-warning { background-color: #ffe680; }
 .rate-good { background-color: #80ff80; }
-button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margin: 0; min-width: 0; min-height: 32px; width: auto; height: auto; white-space: nowrap; }
+button.role-toggle, button.controller-action { font-size: 14px; line-height: 1.2; padding: 6px 10px; margin: 0; min-width: 0; min-height: 32px; width: auto; height: auto; white-space: nowrap; }
 </style>
 {% endblock %}
 
@@ -71,7 +71,7 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
         <table class="controller-table">
         <thead>
             <tr>
-                <th>Status</th>
+                <th>Status</th><th>Identify</th>
                 <th>Updates/s</th><th>Report gap p95</th><th>Longest gap (10 s)</th>
                 <th>Role</th>
                 <th>Switch Role</th>
@@ -80,41 +80,40 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
                 <th>Controller</th>
                 <th>Model</th>
                 <th>Registered</th>
-                <th>Loaded</th>
-                <th>BlueZ Paired</th>
                 <th>Connected</th>
                 <th>Trusted</th>
-                <th>Services</th>
+                <th>Unpair</th>
             </tr>
         </thead>
         <tbody class="controller-status-body" data-for-adapter="{{ adapter.name }}">
             {% for controller in adapter.controllers %}
             <tr data-controller="{{ controller.address }}">
                 <td class="{% if controller.connected %}connected{% else %}disconnected{% endif %}">{{ controller.status }}</td>
+                <td>{% if controller.connected %}<button type="button" class="controller-action" data-action="identify" data-address="{{ controller.address }}" {% if not controller.connected %}disabled{% endif %}>Identify</button>{% endif %}</td>
                 <td class="controller-rate">Measuring…</td>
                 <td>Measuring…</td><td>Measuring…</td>
                 <td>{{ controller.role }}</td>
                 <td>
-                    <button type="button" class="role-toggle" data-address="{{ controller.address }}"
+                    {% if controller.connected and controller.adapter.startswith('hci') and controller.role in ['Central', 'Peripheral'] %}
+                    <button type="button" class="role-toggle"  data-address="{{ controller.address }}"
                             data-role="{{ 'peripheral' if controller.role == 'Central' else 'central' }}"
                             {% if not controller.connected or controller.role not in ['Central', 'Peripheral'] %}disabled{% endif %}>
                         Switch to {{ 'Peripheral' if controller.role == 'Central' else 'Central' }}
                     </button>
+                    {% endif %}
                 </td>
                 <td{% if controller.battery_code is not none %} class="batt{{ controller.battery_code }}"{% endif %}>{{ controller.battery }}</td>
                 <td>{% if controller.active is none %}Unknown{% elif controller.active %}Yes{% else %}No{% endif %}</td>
                 <td>{{ controller.address }}</td>
-                <td>{{ controller.model }}</td>
+                <td>{{ 'ZCM1 (PS3)' if controller.model == 'ZCM1' else ('ZCM2 (PS4)' if controller.model == 'ZCM2' else controller.model) }}</td>
                 <td>Yes</td>
-                <td>{% if controller.loaded %}Yes{% else %}No{% endif %}</td>
-                <td>{% if controller.paired %}Yes{% else %}No{% endif %}</td>
                 <td>{% if controller.connected %}Yes{% else %}No{% endif %}</td>
                 <td>{% if controller.trusted %}Yes{% else %}No{% endif %}</td>
-                <td>{% if controller.services_resolved %}Ready{% else %}Not ready{% endif %}</td>
+                <td><button type="button" class="controller-action" data-action="unpair" data-address="{{ controller.address }}" {% if not controller.can_unpair %}disabled{% endif %}>Unpair</button></td>
             </tr>
             {% else %}
             <tr>
-                <td colspan="16">No controllers are assigned to this adapter.</td>
+                <td colspan="15">No controllers are assigned to this adapter.</td>
             </tr>
             {% endfor %}
         </tbody>
@@ -127,7 +126,24 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
 
     <div id="unassigned-controller-section" class="adapter-section" style="display: none;">
         <h3>Unassigned or unavailable adapter</h3>
-        <table class="controller-table"><tbody class="controller-status-body" data-for-adapter="unknown"></tbody></table>
+        <table class="controller-table">
+        <thead>
+            <tr>
+                <th>Status</th><th>Identify</th>
+                <th>Updates/s</th><th>Report gap p95</th><th>Longest gap (10 s)</th>
+                <th>Role</th>
+                <th>Switch Role</th>
+                <th>Battery</th>
+                <th>Active</th>
+                <th>Controller</th>
+                <th>Model</th>
+                <th>Registered</th>
+                <th>Connected</th>
+                <th>Trusted</th>
+                <th>Unpair</th>
+            </tr>
+        </thead>
+<tbody class="controller-status-body" data-for-adapter="unknown"></tbody></table>
     </div>
     <p><a href="/"><button type="button">Go Back</button></a></p>
     <section aria-labelledby="hotspot-heading">
@@ -152,13 +168,7 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
         <button type="submit" class="danger-button">Reset Bluetooth Controllers</button>
     </form>
     <p class="diagnostic-note">This stops the current game, clears saved PS Move registrations, and restarts JoustMania. Controllers may need to reconnect or be paired again.</p>
-    <section>
-        <h3>Controller Roles</h3>
-        <button type="button" id="all-peripheral">Try All Peripheral</button>
-        <p class="diagnostic-note">Peripheral mode may improve controller data rates, but it can reduce the number of controllers that can connect at once.
-        This makes a one-time switch attempt; roles are not forced afterward.</p>
-        <p id="all-peripheral-status" role="status"></p>
-    </section>
+    <p id="controller-action-error" role="alert"></p>
 </div>
 <script>
 (function () {
@@ -226,7 +236,7 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
     const controllerLast = {};
     const rolePending = {};
     const roleMessages = {};
-    let bulkRolePending = false;
+    const actionPending = {};
     async function switchControllerRole(address, role) {
         rolePending[address] = true;
         roleMessages[address] = 'Switching…';
@@ -246,37 +256,47 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
         }
     }
     document.addEventListener('click', async function (event) {
-        const button = event.target.closest('.role-toggle');
-        if (!button || button.disabled || bulkRolePending) return;
-        button.disabled = true;
-        button.textContent = 'Switching…';
-        document.getElementById('all-peripheral').disabled = true;
-        await switchControllerRole(button.dataset.address, button.dataset.role);
-        document.getElementById('all-peripheral').disabled = Object.keys(rolePending).length > 0;
-    });
-    document.getElementById('all-peripheral').addEventListener('click', async function () {
-        if (bulkRolePending || Object.keys(rolePending).length) return;
-        // Already-Peripheral links need no request. Ignore disconnected/unknown links.
-        const addresses = Array.from(document.querySelectorAll('.role-toggle[data-role="peripheral"]'))
-            .filter(function (button) { return !button.disabled; })
-            .map(function (button) { return button.dataset.address; });
-        const status = document.getElementById('all-peripheral-status');
-        if (!addresses.length) {
-            status.textContent = 'No connected Central-role controllers to switch.';
+        const action = event.target.closest('.controller-action');
+        if (action) {
+            if (action.disabled || actionPending[action.dataset.address]) return;
+            const address = action.dataset.address, kind = action.dataset.action;
+            if (kind === 'unpair' && !window.confirm('Unpair controller ' + address + '? It will disconnect and need USB pairing again.')) return;
+            actionPending[address] = true;
+            action.disabled = true;
+            action.textContent = kind === 'identify' ? 'Identifying…' : 'Unpairing…';
+            try {
+                const response = await fetch('/debug/controller-' + kind, {
+                    method: 'POST', body: new URLSearchParams({address: address})
+                });
+                const data = await response.json();
+                if (!response.ok) throw new Error(data.error || 'Controller action failed.');
+                document.getElementById('controller-action-error').textContent = '';
+            } catch (error) {
+                document.getElementById('controller-action-error').textContent = error.message;
+            } finally {
+                delete actionPending[address];
+            }
             return;
         }
-        bulkRolePending = true;
-        this.disabled = true;
-        let succeeded = 0;
-        for (let index = 0; index < addresses.length; index++) {
-            status.textContent = 'Trying controller ' + (index + 1) + ' of ' + addresses.length + '…';
-            if (await switchControllerRole(addresses[index], 'peripheral')) succeeded++;
-        }
-        bulkRolePending = false;
-        this.disabled = false;
-        status.textContent = 'Switched ' + succeeded + ' of ' + addresses.length +
-            ' controllers to Peripheral. ' + (addresses.length - succeeded) + ' failed; see each controller’s result.';
+        const button = event.target.closest('.role-toggle');
+        if (!button || button.disabled) return;
+        button.disabled = true;
+        button.textContent = 'Switching…';
+        await switchControllerRole(button.dataset.address, button.dataset.role);
     });
+    function actionCell(row, controller, kind) {
+        cell(row, '');
+        if (kind === 'identify' && !controller.connected) return;
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'controller-action';
+        button.dataset.address = controller.address;
+        button.dataset.action = kind;
+        button.textContent = kind === 'identify' ? (controller.identifying ? 'Identifying…' : 'Identify') : 'Unpair';
+        button.disabled = Boolean(actionPending[controller.address]) ||
+            (kind === 'identify' ? (!controller.connected || controller.identifying) : !controller.can_unpair);
+        row.lastElementChild.appendChild(button);
+    }
     function cell(row, value, className) {
         const item = document.createElement('td');
         item.textContent = value;
@@ -312,6 +332,7 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
             const row = document.createElement('tr');
             row.dataset.controller = controller.address;
             cell(row, controller.status, controller.connected ? 'connected' : 'disconnected');
+            actionCell(row, controller, 'identify');
             let rate = 'Unavailable';
             if (!controller.connected) {
                 rate = '—';
@@ -352,16 +373,19 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
             cell(row, controller.role);
             cell(row, '');
             const roleCell = row.lastElementChild;
-            const roleButton = document.createElement('button');
-            roleButton.type = 'button';
-            roleButton.className = 'role-toggle';
-            roleButton.dataset.address = controller.address;
-            roleButton.dataset.role = controller.role === 'Central' ? 'peripheral' : 'central';
-            roleButton.textContent = rolePending[controller.address] ? 'Switching…' :
-                ('Switch to ' + (controller.role === 'Central' ? 'Peripheral' : 'Central'));
-            roleButton.disabled = bulkRolePending || Boolean(rolePending[controller.address]) || !controller.connected ||
-                !['Central', 'Peripheral'].includes(controller.role);
-            roleCell.appendChild(roleButton);
+            if (controller.connected && controller.adapter.startsWith('hci') &&
+                body.dataset.forAdapter !== 'unknown' && ['Central', 'Peripheral'].includes(controller.role)) {
+                const roleButton = document.createElement('button');
+                roleButton.type = 'button';
+                roleButton.className = 'role-toggle';
+                roleButton.dataset.address = controller.address;
+                roleButton.dataset.role = controller.role === 'Central' ? 'peripheral' : 'central';
+                roleButton.textContent = rolePending[controller.address] ? 'Switching…' :
+                    ('Switch to ' + (controller.role === 'Central' ? 'Peripheral' : 'Central'));
+                roleButton.disabled = Boolean(rolePending[controller.address]) || !controller.connected ||
+                    !['Central', 'Peripheral'].includes(controller.role);
+                roleCell.appendChild(roleButton);
+            }
             if (roleMessages[controller.address]) {
                 const message = document.createElement('div');
                 message.setAttribute('role', 'status');
@@ -371,16 +395,17 @@ button.role-toggle { font-size: 14px; line-height: 1.2; padding: 6px 10px; margi
             cell(row, controller.battery, controller.battery_code === null ? '' : 'batt' + controller.battery_code);
             cell(row, controller.active === null ? 'Unknown' : (controller.active ? 'Yes' : 'No'));
             cell(row, controller.address);
-            cell(row, controller.model); cell(row, 'Yes'); cell(row, controller.loaded ? 'Yes' : 'No');
-            cell(row, controller.paired ? 'Yes' : 'No'); cell(row, controller.connected ? 'Yes' : 'No');
-            cell(row, controller.trusted ? 'Yes' : 'No'); cell(row, controller.services_resolved ? 'Ready' : 'Not ready');
+            cell(row, controller.model === 'ZCM1' ? 'ZCM1 (PS3)' : (controller.model === 'ZCM2' ? 'ZCM2 (PS4)' : controller.model)); cell(row, 'Yes');
+            cell(row, controller.connected ? 'Yes' : 'No');
+            cell(row, controller.trusted ? 'Yes' : 'No');
+            actionCell(row, controller, 'unpair');
             body.appendChild(row);
         });
         bodies.forEach(function (body) {
             if (body.children.length) return;
             const row = document.createElement('tr');
             const item = document.createElement('td');
-            item.colSpan = 16;
+            item.colSpan = 15;
             item.textContent = body.dataset.forAdapter === 'unknown'
                 ? 'No unassigned controllers.'
                 : 'No controllers are assigned to this adapter.';

--- a/templates/controller_debug.html
+++ b/templates/controller_debug.html
@@ -239,7 +239,7 @@ button.role-toggle, button.controller-action { font-size: 14px; line-height: 1.2
     const actionPending = {};
     async function switchControllerRole(address, role) {
         rolePending[address] = true;
-        roleMessages[address] = 'Switching…';
+        delete roleMessages[address];
         try {
             const response = await fetch('/debug/controller-role', {
                 method: 'POST', body: new URLSearchParams({address: address, role: role})
@@ -249,7 +249,7 @@ button.role-toggle, button.controller-action { font-size: 14px; line-height: 1.2
             delete roleMessages[address];
             return true;
         } catch (error) {
-            roleMessages[address] = error.message;
+            roleMessages[address] = {text: 'Role change failed', expires: Date.now() + 10000};
             return false;
         } finally {
             delete rolePending[address];
@@ -386,10 +386,13 @@ button.role-toggle, button.controller-action { font-size: 14px; line-height: 1.2
                     !['Central', 'Peripheral'].includes(controller.role);
                 roleCell.appendChild(roleButton);
             }
+            if (roleMessages[controller.address] && Date.now() >= roleMessages[controller.address].expires) {
+                delete roleMessages[controller.address];
+            }
             if (roleMessages[controller.address]) {
                 const message = document.createElement('div');
                 message.setAttribute('role', 'status');
-                message.textContent = roleMessages[controller.address];
+                message.textContent = roleMessages[controller.address].text;
                 roleCell.appendChild(message);
             }
             cell(row, controller.battery, controller.battery_code === null ? '' : 'batt' + controller.battery_code);

--- a/test_controller_actions.py
+++ b/test_controller_actions.py
@@ -1,0 +1,74 @@
+import multiprocessing
+import threading
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import controller_manager
+import psmove_dbus
+import webui
+
+ADDRESS = 'AA:BB:CC:DD:EE:FF'
+ADAPTER = '11:22:33:44:55:66'
+
+
+class ControllerActionsTest(unittest.TestCase):
+    def test_identify_restores_current_color_and_leaves_other_controller_alone(self):
+        with multiprocessing.Manager() as shared:
+            manager = controller_manager.ControllerManager(shared)
+            index = manager.get_or_assign_controller_index(ADDRESS)
+            manager.active[index] = 1
+            manager.leds[:3] = [1, 2, 3]
+            with mock.patch.object(controller_manager.time, 'monotonic', return_value=10):
+                self.assertTrue(manager.request_identify(ADDRESS.lower()))
+                self.assertEqual(manager.output_color(index), (255, 255, 255))
+                self.assertEqual(manager.output_color(1), (0, 0, 0))
+            manager.leds[:3] = [4, 5, 6]
+            with mock.patch.object(controller_manager.time, 'monotonic', return_value=13):
+                self.assertEqual(manager.output_color(index), (4, 5, 6))
+            manager.active[index] = 0
+            self.assertFalse(manager.request_identify(ADDRESS))
+
+    @mock.patch.object(psmove_dbus, 'get_registered_controllers')
+    @mock.patch.object(psmove_dbus.jm_dbus, 'remove_device')
+    @mock.patch('shutil.rmtree')
+    def test_unpair_removes_only_selected_controller_across_adapters(self, remove_saved, remove_live, records):
+        records.return_value = [
+            dict(address=ADDRESS, adapter='hci0', adapter_address=ADAPTER,
+                 loaded=True, device_name='dev_AA_BB_CC_DD_EE_FF'),
+            dict(address=ADDRESS, adapter='unknown', adapter_address=ADAPTER, loaded=False),
+            dict(address='00:00:00:00:00:01', loaded=True),
+        ]
+        self.assertEqual(psmove_dbus.unpair_controller(ADDRESS.lower()), 2)
+        remove_live.assert_called_once_with('hci0', 'dev_AA_BB_CC_DD_EE_FF')
+        self.assertEqual(str(remove_saved.call_args.args[0]),
+                         '/var/lib/bluetooth/' + ADAPTER + '/' + ADDRESS)
+        with self.assertRaises(ValueError):
+            psmove_dbus.unpair_controller('../../')
+        with self.assertRaises(ValueError):
+            psmove_dbus.unpair_controller('00:00:00:00:00:02')
+
+    def test_http_actions_and_pairing_reservation(self):
+        ns = SimpleNamespace(status={}, battery_status={}, pairing_lock=threading.RLock(),
+                             pairing_state={'busy': False, 'reservations': {ADDRESS: ADAPTER, 'OTHER': ADAPTER}})
+        manager = mock.Mock()
+        ui = webui.WebUI(ns=ns, controller_manager_instance=manager)
+        client = ui.app.test_client()
+        with mock.patch.object(ui, '_controller_debug_data', return_value=[dict(address=ADDRESS, connected=True)]):
+            self.assertEqual(client.post('/debug/controller-identify', data={'address': ADDRESS}).status_code, 200)
+            manager.request_identify.assert_called_once_with(ADDRESS)
+        with mock.patch.object(ui, '_controller_debug_data', return_value=[]):
+            self.assertEqual(client.post('/debug/controller-identify', data={'address': ADDRESS}).status_code, 409)
+        with mock.patch.object(psmove_dbus, 'unpair_controller', return_value=1) as remove:
+            ns.pairing_state['busy'] = True
+            self.assertEqual(client.post('/debug/controller-unpair', data={'address': ADDRESS}).status_code, 409)
+            remove.assert_not_called()
+            ns.pairing_state['busy'] = False
+            self.assertEqual(client.post('/debug/controller-unpair', data={'address': ADDRESS}).status_code, 200)
+            self.assertEqual(ns.pairing_state['reservations'], {'OTHER': ADAPTER})
+        for route in ('controller-identify', 'controller-unpair'):
+            self.assertEqual(client.get('/debug/' + route).status_code, 405)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_controller_role_ui.js
+++ b/test_controller_role_ui.js
@@ -36,17 +36,22 @@ const context = {
 };
 vm.runInNewContext(script.replace('}());', 'globalThis.renderControllers = renderControllers; globalThis.connectionAssessment = connectionAssessment; globalThis.renderPairing = renderPairing;}());'), context);
 (async () => {
-    await element('all-peripheral').click();
-    assert.equal(requests.length, 2);
-    assert.equal(maximumActive, 1);
-    assert(requests.every(r => r.url === '/debug/controller-role' && r.role === 'peripheral'));
-    assert.match(element('all-peripheral-status').textContent, /Switched 1 of 2/);
-    assert.match(element('all-peripheral-status').textContent, /1 failed/);
-    assert.equal(element('all-peripheral').disabled, false);
-    requests.length = 0;
     const button = {dataset: {address: 'AA:BB:CC:DD:EE:01', role: 'central'}, disabled: false};
-    await handlers.click({target: {closest() {return button;}}});
+    await handlers.click({target: {closest(selector) {return selector === '.role-toggle' ? button : null;}}});
     assert.equal(requests[0].role, 'central');
+    for (const kind of ['identify', 'unpair']) {
+        requests.length = 0;
+        const action = {dataset: {address: 'AA:BB:CC:DD:EE:01', action: kind}, disabled: false};
+        context.window.confirm = () => false;
+        if (kind === 'unpair') {
+            await handlers.click({target: {closest(selector) {return selector === '.controller-action' ? action : null;}}});
+            assert.equal(requests.length, 0);
+        }
+        context.window.confirm = () => true;
+        await handlers.click({target: {closest(selector) {return selector === '.controller-action' ? action : null;}}});
+        assert.equal(requests[0].url, '/debug/controller-' + kind);
+        assert.equal(requests[0].address, action.dataset.address);
+    }
     function node() {
         return {children: [], dataset: {}, style: {},
             appendChild(child) {this.children.push(child); this.lastElementChild = child;},
@@ -65,24 +70,34 @@ vm.runInNewContext(script.replace('}());', 'globalThis.renderControllers = rende
             last_report_age_ms: 500, sample_count: 600, window_s: 10,
             gaps_over_50ms: 2, gaps_over_100ms: 0}};
     context.renderControllers([controller], 1);
-    assert.equal(body.children[0].children[2].textContent, '36.0 ms');
-    assert.equal(body.children[0].children[3].textContent, '80.0 ms');
-    assert.equal(body.children[0].children[4].textContent, 'Central');
-    assert.equal(body.children[0].children[2].className, 'nowrap rate-slow');
+    assert.equal(body.children[0].children[3].textContent, '36.0 ms');
+    assert.equal(body.children[0].children[4].textContent, '80.0 ms');
+    assert.equal(body.children[0].children[5].textContent, 'Central');
     assert.equal(body.children[0].children[3].className, 'nowrap rate-slow');
+    assert.equal(body.children[0].children[4].className, 'nowrap rate-slow');
     for (const [p95, max, color] of [[22, 30, 'rate-good'], [24, 40, 'rate-warning'], [30, 50, 'rate-warning'], [31, 51, 'rate-slow']]) {
         controller.report_gap.p95_ms = p95; controller.report_gap.max_ms = max;
         context.renderControllers([controller], 1);
-        assert.equal(body.children[0].children[2].className, 'nowrap ' + color);
         assert.equal(body.children[0].children[3].className, 'nowrap ' + color);
+        assert.equal(body.children[0].children[4].className, 'nowrap ' + color);
     }
     controller.connected = false;
     context.renderControllers([controller], 1);
-    assert.equal(body.children[0].children[2].textContent, '—');
-    assert.equal(body.children[0].children[2].className, 'nowrap');
-    controller.connected = true; controller.report_gap = null;
+    assert.equal(body.children[0].children[3].textContent, '—');
+    assert.equal(body.children[0].children[3].className, 'nowrap');
+    assert.equal(body.children[0].children[1].children.length, 0);
+    assert.equal(body.children[0].children[6].children.length, 0);
+    controller.connected = true; controller.role = 'Unavailable';
     context.renderControllers([controller], 1);
-    assert.equal(body.children[0].children[2].textContent, 'Unavailable');
+    assert.equal(body.children[0].children[6].children.length, 0);
+    controller.role = 'Central'; controller.report_gap = null;
+    context.renderControllers([controller], 1);
+    assert.equal(body.children[0].children[3].textContent, 'Unavailable');
+    controller.adapter = 'unknown'; controller.model = 'ZCM2';
+    context.renderControllers([controller], 1);
+    assert.equal(unknown.children[0].children[6].children.length, 0);
+    assert.equal(unknown.children[0].children[10].textContent, 'ZCM2 (PS4)');
+    assert.equal(unknown.children[0].children.length, 15);
     const adapter = {name: 'hci0', connections: 2};
     const link = p95 => ({adapter: 'hci0', connected: true, report_gap: {p95_ms: p95}});
     assert.equal(context.connectionAssessment(adapter, [link(20), link(36)]), 'Mixed: 1 good, 1 slow');

--- a/test_controller_role_ui.js
+++ b/test_controller_role_ui.js
@@ -15,7 +15,9 @@ const targets = [
 ];
 const requests = [];
 let active = 0, maximumActive = 0;
+let now = 1000;
 const context = {
+    Date: {now: () => now},
     document: {
         getElementById: element,
         addEventListener(type, fn) {handlers[type] = fn;},
@@ -34,7 +36,7 @@ const context = {
         return {ok, async json() {return ok ? {role: 'Peripheral'} : {error: 'Switch rejected'};}};
     }
 };
-vm.runInNewContext(script.replace('}());', 'globalThis.renderControllers = renderControllers; globalThis.connectionAssessment = connectionAssessment; globalThis.renderPairing = renderPairing;}());'), context);
+vm.runInNewContext(script.replace('}());', 'globalThis.switchControllerRole = switchControllerRole; globalThis.renderControllers = renderControllers; globalThis.connectionAssessment = connectionAssessment; globalThis.renderPairing = renderPairing;}());'), context);
 (async () => {
     const button = {dataset: {address: 'AA:BB:CC:DD:EE:01', role: 'central'}, disabled: false};
     await handlers.click({target: {closest(selector) {return selector === '.role-toggle' ? button : null;}}});
@@ -98,6 +100,16 @@ vm.runInNewContext(script.replace('}());', 'globalThis.renderControllers = rende
     assert.equal(unknown.children[0].children[6].children.length, 0);
     assert.equal(unknown.children[0].children[10].textContent, 'ZCM2 (PS4)');
     assert.equal(unknown.children[0].children.length, 15);
+    controller.adapter = 'hci0'; controller.address = 'AA:BB:CC:DD:EE:02';
+    await context.switchControllerRole(controller.address, 'peripheral');
+    context.renderControllers([controller], 1);
+    assert.equal(body.children[0].children[6].children[1].textContent, 'Role change failed');
+    now += 9999;
+    context.renderControllers([controller], 1);
+    assert.equal(body.children[0].children[6].children.length, 2);
+    now += 1;
+    context.renderControllers([controller], 1);
+    assert.equal(body.children[0].children[6].children.length, 1);
     const adapter = {name: 'hci0', connections: 2};
     const link = p95 => ({adapter: 'hci0', connected: true, report_gap: {p95_ms: p95}});
     assert.equal(context.connectionAssessment(adapter, [link(20), link(36)]), 'Mixed: 1 good, 1 slow');

--- a/test_controller_roles_web.py
+++ b/test_controller_roles_web.py
@@ -12,7 +12,7 @@ class ControllerRolesWebTest(unittest.TestCase):
         self.ui = webui.WebUI(ns=SimpleNamespace(status={}, battery_status={}))
         self.client = self.ui.app.test_client()
         self.controllers = mock.patch.object(self.ui, '_controller_debug_data', return_value=[
-            {'address': ADDRESS, 'connected': True}
+            {'address': ADDRESS, 'connected': True, 'adapter': 'hci0', 'role': 'Central'}
         ])
         self.controllers.start()
         self.addCleanup(self.controllers.stop)
@@ -34,6 +34,15 @@ class ControllerRolesWebTest(unittest.TestCase):
         switch.assert_not_called()
 
     @mock.patch.object(webui.bluetooth_roles, 'set_connection_role')
+    def test_unavailable_adapter_or_role_cannot_be_switched(self, switch):
+        controller = self.ui._controller_debug_data.return_value[0]
+        for adapter, role in [('unknown', 'Central'), ('hci0', 'Unavailable')]:
+            controller.update(adapter=adapter, role=role)
+            self.assertEqual(self.client.post('/debug/controller-role',
+                data={'address': ADDRESS, 'role': 'peripheral'}).status_code, 409)
+        switch.assert_not_called()
+
+    @mock.patch.object(webui.bluetooth_roles, 'set_connection_role')
     def test_invalid_role_does_not_reach_hardware(self, switch):
         response = self.client.post('/debug/controller-role', data={'address': ADDRESS, 'role': 'toggle'})
         self.assertEqual(response.status_code, 400)
@@ -50,7 +59,7 @@ class ControllerRolesWebTest(unittest.TestCase):
         self.assertEqual(self.client.post('/debug/controller-role').status_code, 501)
 
     @mock.patch.object(webui.bluetooth_diagnostics, 'get_adapters', return_value=[{'name': 'hci0', 'rx_errors': 0, 'tx_errors': 0}])
-    def test_debug_page_renders_manual_and_bulk_controls(self, adapters):
+    def test_debug_page_renders_individual_controls(self, adapters):
         self.ui._controller_debug_data.return_value = [{
             'address': ADDRESS, 'adapter': 'hci0', 'connected': True,
             'role': 'Central', 'battery_code': None,
@@ -59,8 +68,17 @@ class ControllerRolesWebTest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'Switch to Peripheral', response.data)
         self.assertIn(b'<th>Switch Role</th>', response.data)
-        self.assertIn(b'Try All Peripheral', response.data)
-        self.assertIn(b'reduce the number of controllers', response.data)
+        self.assertNotIn(b'Try All Peripheral', response.data)
+        self.assertIn(b'<th>Unpair</th>', response.data)
+        self.assertIn(b'<th>Identify</th>', response.data)
+        self.ui._controller_debug_data.return_value[0]['connected'] = False
+        response = self.client.get('/debug')
+        self.assertNotIn(b'data-action="identify"', response.data)
+        self.assertNotIn(b'class="role-toggle"', response.data)
+        self.assertIn(b'data-action="unpair"', response.data)
+        for heading in ('Loaded', 'BlueZ Paired', 'Services'):
+            self.assertNotIn(('<th>' + heading + '</th>').encode(), response.data)
+
 
 
 if __name__ == '__main__':

--- a/webui.py
+++ b/webui.py
@@ -1,3 +1,4 @@
+import time
 import pairing_plan
 from multiprocessing import Queue, Manager, Process
 import socket
@@ -112,6 +113,8 @@ class WebUI():
         self.app.add_url_rule('/debug/controllers','controller_debug_legacy',self.controller_debug_legacy)
         self.app.add_url_rule('/debug/data','debug_data',self.debug_data)
         self.app.add_url_rule('/debug/pairing-target', 'pairing_target', self.change_pairing_target, methods=['POST'])
+        self.app.add_url_rule('/debug/controller-identify', 'controller_identify', self.identify_controller, methods=['POST'])
+        self.app.add_url_rule('/debug/controller-unpair', 'controller_unpair', self.unpair_controller, methods=['POST'])
         self.app.add_url_rule('/debug/controller-role', 'controller_role', self.change_controller_role, methods=['POST'])
         self.app.add_url_rule('/debug/access-point', 'access_point', self.change_access_point, methods=['POST'])
         self.app.add_url_rule(
@@ -206,6 +209,39 @@ class WebUI():
         except ValueError as error:
             return {'error': str(error)}, 409
 
+    def identify_controller(self):
+        address = request.form.get('address', '').strip().upper()
+        connected = any(c['address'].upper() == address and c['connected']
+                        for c in self._controller_debug_data())
+        if not connected or self.controller_manager is None or not self.controller_manager.request_identify(address):
+            return {'error': 'Controller is not connected and available.'}, 409
+        return {'success': True, 'duration_s': 3}
+
+    def unpair_controller(self):
+        if psmove_dbus is None:
+            return {'error': 'Individual unpairing is only available on Linux.'}, 501
+        address = request.form.get('address', '').strip().upper()
+        # Serialize against USB pairing so its reservation cannot reappear.
+        def remove():
+            removed = psmove_dbus.unpair_controller(address)
+            if hasattr(self.ns, 'pairing_state'):
+                reservations = dict(self.ns.pairing_state['reservations'])
+                reservations.pop(address, None)
+                self.ns.pairing_state['reservations'] = reservations
+                self.ns.pairing_state['refreshed'] = 0.0
+            return {'success': True, 'removed': removed}
+        try:
+            if hasattr(self.ns, 'pairing_state'):
+                with self.ns.pairing_lock:
+                    if self.ns.pairing_state['busy']:
+                        return {'error': 'Wait for USB pairing to finish.'}, 409
+                    return remove()
+            return remove()
+        except ValueError as error:
+            return {'error': str(error)}, 400
+        except Exception as error:
+            return {'error': 'Unable to unpair controller: ' + str(error)}, 409
+
     def change_controller_role(self):
         if bluetooth_roles is None:
             return {'error': 'Role switching is only available on Linux.'}, 501
@@ -214,7 +250,9 @@ class WebUI():
         if role not in ('central', 'peripheral'):
             return {'error': 'Choose Central or Peripheral.'}, 400
         controller = next((c for c in self._controller_debug_data()
-                           if c['address'].upper() == address and c['connected']), None)
+                           if c['address'].upper() == address and c['connected']
+                           and c.get('adapter', '').startswith('hci')
+                           and c.get('role') in ('Central', 'Peripheral')), None)
         if controller is None:
             return {'error': 'Controller is not connected over Bluetooth.'}, 409
         try:
@@ -361,6 +399,13 @@ class WebUI():
             )
             controller['update_count'] = update_counts.get(address) if controller['connected'] else None
             controller['report_gap'] = report_gaps.get(address) if controller['connected'] else None
+            controller['identifying'] = False
+            if self.controller_manager is not None and controller['connected']:
+                controller['identifying'] = any(
+                    self.controller_manager.index_to_serial[i].upper() == address and
+                    self.controller_manager.identify_until[i] > time.monotonic()
+                    for i in self.controller_manager.active_controller_indices())
+            controller['can_unpair'] = psmove_dbus is not None
 
         if bluetooth_roles is not None:
             try:


### PR DESCRIPTION
System Debug now provides individual controller actions: Identify immediately after Status shows white for three seconds, then restores the color currently requested by the game; Unpair in the final column removes only that PS Move's host registrations, including saved registrations on unavailable adapters. Unpair asks for confirmation and releases the controller's session assignment in the pairing algorithm. It is blocked while USB pairing is in progress.

Identify is hidden for disconnected controllers. Individual role switches are hidden for disconnected controllers, unavailable adapters, and unknown roles; the server also rejects those role requests. Role-switch failures show “Role change failed” for ten seconds, then clear on the next status refresh. Removed the Try All Peripheral section and its bulk-action code. Removed Loaded, BlueZ Paired, and Services columns, and labeled models ZCM1 (PS3) and ZCM2 (PS4).

Validation: 26 Python tests and the JavaScript UI tests pass. Tests cover Identify color restoration and controller isolation, targeted live/saved registration removal, pairing reservation cleanup, HTTP validation, action routing and cancellation, and hidden controls. On the Pi, verified the live Identify request and three-second state expiry plus rendered column and button visibility. Physical LED appearance was not visually verified; Unpair was tested with mocks to preserve the current test controllers.

No new dependencies. Individual Unpair is Linux-only. Stacked on #382 to keep this draft limited to controller actions and table cleanup.
